### PR TITLE
Flip Phase 0 status to complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,11 @@ Non-normative human docs live in [`docs/`](docs/).
 
 ## Current phase
 
-**Phase 0 (bootstrap) in progress.** Scaffolding is in place; the
-remaining steps (commit, push, branch protection) finish the phase.
-No code yet. See [`docs/roadmap.md`](docs/roadmap.md) for the full
-13-phase plan. The spec itself is not yet written —
+**Phase 0 (bootstrap) complete.** Scaffolding, docs, and CI
+(`docs-lint`) are in place; `main` is protected. No code yet.
+Phase 1 (next) writes the core-concepts chapters of `spec/v0/` and
+the first JSON Schemas. See [`docs/roadmap.md`](docs/roadmap.md) for
+the full 13-phase plan. The spec itself is not yet written —
 [`spec/v0/README.md`](spec/v0/README.md) lists the planned chapters
 with their target phases.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ implementation** (`reference/`), and the **conformance suite**
 
 ## Current phase
 
-**Phase 0 (bootstrap) in progress.** Scaffolding and docs are in place;
-first commit + push + branch protection finish the phase. There is no
+**Phase 0 (bootstrap) complete.** Scaffolding, docs, and CI
+(`docs-lint`) are in place and `main` is protected. There is no
 runnable code yet — the reference implementation and conformance suite
 are stubs. The spec itself is not yet written; only the section READMEs
 exist. See [`docs/roadmap.md`](docs/roadmap.md) for the full 13-phase

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ with other conforming components.
 
 ## Status
 
-**Phase 0 (bootstrap) in progress.** The scaffolding, documentation, and
-CI are in place; first commit + push + branch protection complete the
-phase. There is **no runnable code yet**. See
-[`docs/roadmap.md`](docs/roadmap.md) for the full Phase 0–13 plan; the
-next phase (Phase 1) writes the core-concepts chapters of the spec and
-the JSON Schemas for the shared data model.
+**Phase 0 (bootstrap) complete.** Scaffolding, documentation, and CI
+are in place; `main` has its first commit, CI (`docs-lint`) is green,
+and branch protection is enabled. There is **no runnable code yet**.
+See [`docs/roadmap.md`](docs/roadmap.md) for the full Phase 0–13 plan;
+the next phase (Phase 1) writes the core-concepts chapters of the spec
+and the JSON Schemas for the shared data model.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Phase 0 side-effects (commit, push, CI green, branch protection) all
  landed after the bootstrap commit, so the status sections in
  README.md, AGENTS.md, and CONTRIBUTING.md now read "Phase 0
  (bootstrap) complete" and point at Phase 1 as next.
- Doubles as the first PR-flow exercise against the newly protected
  `main` branch — validates that the required `docs-lint` check, the
  PR-required rule, and the merge path all work end-to-end before we
  rely on them in Phase 1.

## Test plan

- [x] Local `npx --yes markdownlint-cli2@0.14.0 ...` passes 0 errors
- [ ] `docs-lint` CI green on this PR
- [ ] PR mergeable with only the required check (no approvals needed
      on a solo repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)