### PR TITLE
Flip Phase 1 status to complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,15 @@ Non-normative human docs live in [`docs/`](docs/).
 
 ## Current phase
 
-**Phase 1 in progress.** `spec/v0/` core-concepts chapters
+**Phase 1 complete.** `spec/v0/` core-concepts chapters
 (`00-overview.md`, `01-concepts.md`, `02-data-model.md`) and the
-first six JSON Schemas under `spec/v0/schemas/` are in place, and
-the `schema-validity` CI job validates them against the Draft 2020-12
-meta-schema and validates the migrated experiment fixture against
-`experiment-config.schema.json`. See [`docs/roadmap.md`](docs/roadmap.md)
-for the full 13-phase plan. Phase 2 next writes the role contracts
-and the task-protocol state machine.
+first six JSON Schemas under `spec/v0/schemas/` are on a protected
+`main`, and the `schema-validity` CI job validates them against the
+Draft 2020-12 meta-schema and validates the migrated experiment
+fixture against `experiment-config.schema.json`. See
+[`docs/roadmap.md`](docs/roadmap.md) for the full 13-phase plan.
+Phase 2 next writes the role contracts and the task-protocol state
+machine.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ with other conforming components.
 
 ## Status
 
-**Phase 1 in progress.** Scaffolding, documentation, and CI are in
-place on a protected `main`; the Phase 1 spec work (core-concepts
-chapters of `spec/v0/`, six JSON Schemas, fixture migration,
-`schema-validity` CI job) is on a feature branch awaiting review.
-There is still **no runnable code yet** — the reference
-implementation lands in Phase 3. See
+**Phase 1 complete.** The core-concepts chapters of `spec/v0/`
+(`00-overview.md`, `01-concepts.md`, `02-data-model.md`), six JSON
+Schemas under `spec/v0/schemas/`, the migrated experiment fixture,
+and the `schema-validity` CI job are in place on a protected `main`;
+both CI checks are green. There is still **no runnable code yet** —
+the reference implementation lands in Phase 3. Phase 2 next writes
+the role contracts and the task-protocol state machine. See
 [`docs/roadmap.md`](docs/roadmap.md) for the full Phase 0–13 plan.
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Phase 1 merged to `main` in #2 with both CI checks green; update `README.md` and `AGENTS.md` status sections to match the realized state.
- Per the status-language-matches-state rule: a commit claiming \"complete\" only lands after the side-effects that justify it have happened.

## Test plan

- [x] `npx --yes markdownlint-cli2@0.14.0 "**/*.md" ...` — 0 errors
- [ ] CI `docs-lint` green
- [ ] CI `schema-validity` green