### PR TITLE
Flip Phase 2 status to complete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,15 +18,15 @@ Non-normative human docs live in [`docs/`](docs/).
 
 ## Current phase
 
-**Phase 1 complete.** `spec/v0/` core-concepts chapters
-(`00-overview.md`, `01-concepts.md`, `02-data-model.md`) and the
-first six JSON Schemas under `spec/v0/schemas/` are on a protected
-`main`, and the `schema-validity` CI job validates them against the
-Draft 2020-12 meta-schema and validates the migrated experiment
-fixture against `experiment-config.schema.json`. See
+**Phase 2 complete.** `spec/v0/03-roles.md` (planner, implementer,
+evaluator, integrator contracts) and `spec/v0/04-task-protocol.md`
+(state machine, claim tokens, idempotent submit, reclamation) have
+merged to the protected `main`, alongside the Phase 1 core-concepts
+chapters and six JSON Schemas. Both CI checks (`docs-lint` and
+`schema-validity`) remain green. See
 [`docs/roadmap.md`](docs/roadmap.md) for the full 13-phase plan.
-Phase 2 next writes the role contracts and the task-protocol state
-machine.
+Phase 3 next ports a Pydantic-bound reference contracts package and
+wires schema-model parity into CI.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,18 @@ with other conforming components.
 
 ## Status
 
-**Phase 1 complete.** The core-concepts chapters of `spec/v0/`
-(`00-overview.md`, `01-concepts.md`, `02-data-model.md`), six JSON
-Schemas under `spec/v0/schemas/`, the migrated experiment fixture,
-and the `schema-validity` CI job are in place on a protected `main`;
-both CI checks are green. There is still **no runnable code yet** —
-the reference implementation lands in Phase 3. Phase 2 next writes
-the role contracts and the task-protocol state machine. See
+**Phase 2 complete.** Both Phase 2 chapters have landed on the
+protected `main`: `spec/v0/03-roles.md` (planner, implementer,
+evaluator, integrator contracts) and `spec/v0/04-task-protocol.md`
+(task state machine, claim tokens, idempotent submission,
+reclamation policy). Together with the Phase 1 core-concepts
+chapters, six JSON Schemas, the migrated experiment fixture, and
+the `docs-lint` + `schema-validity` CI jobs, the protocol surface
+the reference implementation will target is fully specified for
+the planner/implementer/evaluator lifecycle. There is still **no
+runnable code yet** — the reference implementation lands in
+Phase 3. Phase 3 next ports a Pydantic-bound reference contracts
+package and wires schema-model parity into CI. See
 [`docs/roadmap.md`](docs/roadmap.md) for the full Phase 0–13 plan.
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Updates the "Status" / "Current phase" sections in `README.md` and `AGENTS.md` to reflect that Phase 2 (role contracts + task protocol) has merged to `main`.
- Points the next step at Phase 3 (Pydantic-bound reference contracts + schema-model parity CI).

## Phase

Administrative follow-up to PR #4.

## Test plan

- [x] `markdownlint-cli2` clean
- [ ] `docs-lint` + `schema-validity` CI jobs green