### PR TITLE
Codify Pydantic ↔ JSON Schema parity discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,47 @@ These are listed for orientation; the tooling is not wired up yet.
 + The reference impl is explicitly not a monopoly on correctness. A
   third-party implementation that passes conformance is equally valid.
 
+### Adding or extending a JSON Schema + Pydantic binding
+
+The `schema-parity` CI job is only as strong as what both sides of the
+test actually enforce. Several Pydantic and `jsonschema` defaults let
+drift through silently. When adding a new schema — or a new field type
+to an existing one — evaluate each of the following; reusable
+implementations live in
+[`reference/packages/eden-contracts/src/eden_contracts/_common.py`](reference/packages/eden-contracts/src/eden_contracts/_common.py).
+
++ **Strict numeric parsing.** Top-level models set
+  `ConfigDict(strict=True, extra="allow")`. Non-strict mode coerces
+  `True`/`"2"` into int, but the schemas treat `type: integer` /
+  `type: number` as strict JSON types. New models must keep
+  `strict=True`.
++ **Format assertions on both sides.** `format` keywords (`uri`,
+  `date-time`, …) are advisory by default in both the `jsonschema`
+  library and Pydantic. The schema-side validator wires a custom
+  `FormatChecker` in
+  [`tests/conftest.py`](reference/packages/eden-contracts/tests/conftest.py),
+  and the model side uses the reusable types in `_common.py`. A new
+  `format` keyword in any schema requires handlers on *both* sides;
+  the `test_format_coverage` test fails loudly if the schema-side
+  handler is missing.
++ **Real date-time / URI validation, not just regex or `urlparse`.**
+  The regex on `DateTimeStr` accepts impossible values like
+  `2026-99-99T…Z`; an `AfterValidator` runs `datetime.fromisoformat`
+  to reject those. `UriStr` uses `rfc3986-validator`, not
+  `urllib.parse.urlparse`, which accepts malformed schemeful URIs
+  (e.g., spaces in the host).
++ **Null vs absent.** JSON Schema's `type: X` rejects explicit `null`,
+  but Pydantic's `X | None = None` accepts it. Wrap every optional
+  typed field with `NotNone` from `_common.py` so absent is accepted
+  and explicit null is rejected.
++ **Round-trip emission.** `model.model_dump(mode="json",
+  exclude_none=True)` must re-validate against the schema. Add any
+  new model to `tests/test_roundtrip.py` so this is checked.
++ **Corpus coverage.** Parity is asserted over the fixture corpus in
+  `tests/cases.py`. A new field type deserves at least one accept
+  fixture and one reject fixture per constraint the schema imposes
+  (required, pattern, enum, min/max, format, cross-field).
+
 ## Commit guidelines
 
 + Short imperative subjects (e.g., "Add event protocol chapter",

--- a/reference/packages/eden-contracts/tests/conftest.py
+++ b/reference/packages/eden-contracts/tests/conftest.py
@@ -47,10 +47,30 @@ MODEL_NAMES: tuple[str, ...] = (
 )
 
 
-_FORMAT_CHECKER = FormatChecker()
+FORMAT_CHECKER = FormatChecker()
+
+EXPLICIT_FORMATS: set[str] = set()
+"""Formats with a custom handler registered below.
+
+``jsonschema.FormatChecker()`` pre-registers permissive defaults for
+many well-known formats (``uri``, ``email``, ``uuid``, …), so a naive
+"is this format in the checker?" test green-lights any format at all.
+We want parity to be explicit — every format the schemas use has a
+handler we wrote, with matching enforcement on the model side — so
+we track our deliberate registrations separately from the built-ins.
+"""
 
 
-@_FORMAT_CHECKER.checks("uri", raises=ValueError)
+def _register_format(name: str) -> Any:
+    def decorator(func: Any) -> Any:
+        EXPLICIT_FORMATS.add(name)
+        FORMAT_CHECKER.checks(name, raises=ValueError)(func)
+        return func
+
+    return decorator
+
+
+@_register_format("uri")
 def _check_uri(instance: Any) -> bool:
     if not isinstance(instance, str):
         return True
@@ -59,7 +79,7 @@ def _check_uri(instance: Any) -> bool:
     return True
 
 
-@_FORMAT_CHECKER.checks("date-time", raises=ValueError)
+@_register_format("date-time")
 def _check_datetime(instance: Any) -> bool:
     if not isinstance(instance, str):
         return True
@@ -84,7 +104,7 @@ def schema_validator(name: str) -> Draft202012Validator:
     return Draft202012Validator(
         schema={"$ref": f"{BASE_URI}{name}.schema.json"},
         registry=_REGISTRY,
-        format_checker=_FORMAT_CHECKER,
+        format_checker=FORMAT_CHECKER,
     )
 
 

--- a/reference/packages/eden-contracts/tests/test_format_coverage.py
+++ b/reference/packages/eden-contracts/tests/test_format_coverage.py
@@ -1,0 +1,49 @@
+"""Every ``format`` declared in a spec schema has a FormatChecker handler.
+
+Without this test, adding (say) ``format: email`` to a new schema would
+silently pass the parity validator — the JSON Schema ``format`` keyword
+is advisory by default, and ``jsonschema`` enforces only the formats
+registered in the supplied FormatChecker. The parity contract would
+weaken, and the per-schema test_schema_parity would still be green.
+
+This test fails loudly when a new format appears in any schema without
+a corresponding ``@FORMAT_CHECKER.checks("...")`` handler in
+conftest.py, so the gap can't go unnoticed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .conftest import EXPLICIT_FORMATS, SCHEMAS_DIR
+
+
+def _collect_formats(node: Any, out: set[str]) -> None:
+    if isinstance(node, dict):
+        fmt = node.get("format")
+        if isinstance(fmt, str):
+            out.add(fmt)
+        for value in node.values():
+            _collect_formats(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _collect_formats(item, out)
+
+
+def test_every_schema_format_has_a_checker() -> None:
+    used: set[str] = set()
+    for path in sorted(SCHEMAS_DIR.glob("*.schema.json")):
+        schema = json.loads(path.read_text())
+        _collect_formats(schema, used)
+
+    missing = used - EXPLICIT_FORMATS
+    assert not missing, (
+        f"schemas declare format(s) {sorted(missing)} but tests/conftest.py "
+        f"has no explicit `@_register_format(...)` handler for them. "
+        f"jsonschema's built-in FormatChecker defaults are permissive and "
+        f"don't necessarily match the model-side enforcement — add a "
+        f"handler in conftest.py AND a matching validator in "
+        f"reference/packages/eden-contracts/src/eden_contracts/_common.py "
+        f"for each missing format."
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/test_format_coverage.py` — a mechanical check that every `format` keyword in a spec schema has an explicit `@_register_format(...)` handler in `conftest.py`. Tracks deliberate registrations in `EXPLICIT_FORMATS` rather than `FormatChecker.checkers`, since jsonschema pre-registers permissive defaults for many common formats that would hide real coverage gaps.
- Expands `AGENTS.md` "Contribution conventions" with a concrete parity checklist for adding a new JSON Schema + Pydantic binding — strict numerics, format assertions on both sides, real date-time / URI validators, null vs absent, round-trip emission, corpus coverage — each item pointing at the reusable helper already in `_common.py` / `conftest.py`.

Captures the lessons from Phase 3's codex-review loop so the next schema addition (Phase 4's event schema) doesn't re-discover the same defaults.

## Test plan

- [ ] All six CI checks green
- [ ] Self-verified: injecting `format: email` into a schema makes `test_format_coverage` fail with an actionable message; revert returns it to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)