### PR TITLE
Document tests-dir basename convention in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,18 @@ These are listed for orientation; the tooling is not wired up yet.
 + Normative behavior is tested against the conformance suite (once it exists in Phase 11).
 + The reference impl is explicitly not a monopoly on correctness. A third-party implementation that passes conformance is equally valid.
 
+### Adding a new service or package with its own `tests/` directory
+
+Pytest's default `prepend` import mode names test modules by file basename, so two `tests/test_app.py` files in different packages collide on collection (`import file mismatch`). The repo's tests-dir layout is mixed — some packages (e.g. [`eden-contracts/tests/`](reference/packages/eden-contracts/tests/)) have `__init__.py` and use `from .conftest import …`; most service test dirs (e.g. [`web-ui/tests/`](reference/services/web-ui/tests/)) have no `__init__.py` and use `from conftest import …`.
+
+When adding a new tests directory:
+
++ Use a basename that is unique across the whole `testpaths` set in [`pyproject.toml`](pyproject.toml). Grep `find reference -name 'test_*.py' -exec basename {} \;` to verify before merging.
++ Do **not** add `__init__.py` to a service tests dir while another tests dir already has one — both directories become the `tests` package and the second conftest collides on `tests.conftest` import/registration. Under default `prepend` mode this surfaces as `ImportPathMismatchError`; under `importlib` mode it surfaces as `Plugin already registered under a different name`.
++ Switching the whole repo to `--import-mode=importlib` looks tempting but is **not** a clean fix today: the existing eden-contracts tests use relative `.conftest` imports that depend on the `__init__.py` package layout, and importlib mode keeps that collision while removing the sys.path hack the rest of the suite relies on.
+
+If the constraint becomes load-bearing later (Phase 10 will add several more service test dirs), the cleanest fix is a three-step lockstep: rename each tests dir to a unique package name (e.g. `web_ui_tests/` instead of `tests/`), switch every bare `from conftest import …` to a package-relative `from .conftest import …`, and add `--import-mode=importlib` to pytest's `addopts`. A mechanical basename-uniqueness check in CI is also a sensible follow-up — AGENTS-only guidance is weaker than a guardrail.
+
 ### Adding or extending a JSON Schema + Pydantic binding
 
 The `schema-parity` CI job is only as strong as what both sides of the test actually enforce. Several Pydantic and `jsonschema` defaults let drift through silently. When adding a new schema — or a new field type to an existing one — evaluate each of the following; reusable implementations live in [`reference/packages/eden-contracts/src/eden_contracts/_common.py`](reference/packages/eden-contracts/src/eden_contracts/_common.py).

--- a/docs/plans/review/eden-tests-dir-convention/20260424T210747/0-review.md
+++ b/docs/plans/review/eden-tests-dir-convention/20260424T210747/0-review.md
@@ -1,0 +1,12 @@
+Findings:
+
+- [AGENTS.md](/Users/ericalt/Documents/eden/AGENTS.md:82): the rule is right, but the pinned failure text is too specific. In this repo shape, a second `tests/__init__.py` fails as `ImportPathMismatchError` under default `prepend`; the `Plugin already registered under a different name` error shows up under `--import-mode=importlib`. I’d reword this to “collides on `tests.conftest` import/registration” instead of naming one exact error.
+- [AGENTS.md](/Users/ericalt/Documents/eden/AGENTS.md:85): point 6 is realistic, but incomplete. `unique-package-name + importlib` also requires updating bare service-test imports like `from conftest` to package-relative imports, or those tests will stop importing.
+
+Otherwise the substance is accurate. The repo state matches the note: `pyproject.toml` has default pytest import mode, only `reference/packages/eden-contracts/tests` has `__init__.py`, and duplicate bare `test_app.py` names do collide under `prepend`.
+
+`consider_namespace_packages` is probably not worth mentioning here. It helps with namespace-package resolution, but your problem is multiple dirs literally named `tests`, and paths like `eden-contracts` / `web-ui` are not clean package names anyway.
+
+Scope is fine in `AGENTS.md` under contribution conventions: this is a repo-wide contributor trap, not just a local helper detail. I would consider adding an automated basename-uniqueness check later, since this is mechanical and AGENTS-only guidance is weaker than a guardrail.
+
+Sources: pytest docs on import modes and good practices: https://docs.pytest.org/en/latest/explanation/pythonpath.html , https://docs.pytest.org/en/latest/explanation/goodpractices.html

--- a/docs/plans/review/eden-tests-dir-convention/20260424T210747/0.patch
+++ b/docs/plans/review/eden-tests-dir-convention/20260424T210747/0.patch
@@ -1,0 +1,23 @@
+diff --git a/AGENTS.md b/AGENTS.md
+index 6a34ccf..d712138 100644
+--- a/AGENTS.md
++++ b/AGENTS.md
+@@ -72,6 +72,18 @@ These are listed for orientation; the tooling is not wired up yet.
+ + Normative behavior is tested against the conformance suite (once it exists in Phase 11).
+ + The reference impl is explicitly not a monopoly on correctness. A third-party implementation that passes conformance is equally valid.
+ 
++### Adding a new service or package with its own `tests/` directory
++
++Pytest's default `prepend` import mode names test modules by file basename, so two `tests/test_app.py` files in different packages collide on collection (`import file mismatch`). The repo's tests-dir layout is mixed — some packages (e.g. [`eden-contracts/tests/`](reference/packages/eden-contracts/tests/)) have `__init__.py` and use `from .conftest import …`; most service test dirs (e.g. [`web-ui/tests/`](reference/services/web-ui/tests/)) have no `__init__.py` and use `from conftest import …`.
++
++When adding a new tests directory:
++
+++ Use a basename that is unique across the whole `testpaths` set in [`pyproject.toml`](pyproject.toml). Grep `find reference -name 'test_*.py' -exec basename {} \;` to verify before merging.
+++ Do **not** add `__init__.py` to a service tests dir while another tests dir already has one — both directories become the `tests` package and pytest's plugin manager rejects the second conftest with `Plugin already registered under a different name`.
+++ Switching the whole repo to `--import-mode=importlib` looks tempting but is **not** a clean fix today: the existing eden-contracts tests use relative `.conftest` imports that depend on the `__init__.py` package layout, and importlib mode keeps that collision while removing the sys.path hack the rest of the suite relies on.
++
++If the constraint becomes load-bearing later (Phase 10 will add several more service test dirs), the cleanest fix is to give each tests dir a unique package name (e.g. `web_ui_tests/` instead of `tests/`) and switch to importlib mode in lockstep.
++
+ ### Adding or extending a JSON Schema + Pydantic binding
+ 
+ The `schema-parity` CI job is only as strong as what both sides of the test actually enforce. Several Pydantic and `jsonschema` defaults let drift through silently. When adding a new schema — or a new field type to an existing one — evaluate each of the following; reusable implementations live in [`reference/packages/eden-contracts/src/eden_contracts/_common.py`](reference/packages/eden-contracts/src/eden_contracts/_common.py).


### PR DESCRIPTION
## Summary

Phase 9 chunk 1 hit a pytest test-file basename collision (`tests/test_app.py` in two packages). Worked around by renaming. Tried to make it mechanically impossible by switching to `--import-mode=importlib` but eden-contracts/tests' existing `__init__.py` causes a worse collision under importlib mode (conftest plugin registration).

This change documents the trap in AGENTS.md so future contributors hit it on the docs, not on collection. Pins the cleanest mechanical remediation for when Phase 10 makes it worth doing.

Branch name (`pytest-importmode-importlib`) is now slightly misleading — it's the trail of an idea I tried and rolled back. Keeping it for the squash-merge title context.

## Codex review

Round 0 caught two issues:

1. The failure-mode error name in the docs was specific to one import mode — both surface depending on which mode you're running. Corrected to name both.
2. The Phase-10 remediation recipe omitted updating bare `from conftest import …` to relative imports. Added.

No outstanding findings.

## Test plan

- [x] `markdownlint-cli2` — clean
- [x] `uv run pytest -q` — 453 tests still pass (no behavioral change)
- [x] No code changes; AGENTS.md docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)