### PR TITLE
Route IllegalTransition through read-back in planner + implementer (§K-2)

### DIFF
--- a/reference/services/web-ui/src/eden_web_ui/routes/implementer.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/implementer.py
@@ -362,7 +362,7 @@ def _retry_submit_with_readback(
     token: str,
     submission: ImplementSubmission,
 ) -> tuple[str, str | None]:
-    """Submit with retry, then reconcile transport-shape failures via read-back.
+    """Submit with retry, then reconcile via committed-state read-back.
 
     Returns one of:
 
@@ -371,9 +371,9 @@ def _retry_submit_with_readback(
       confirmed a prior committed equivalent submission).
     - ``("auto", banner)`` — orphan page; auto-recovers via reclaim.
       Used for retry exhaustion where the read-back showed the
-      claim is still ours (sub-case B), where it shows a different
-      claim or pending state, where ``WrongToken`` /
-      ``IllegalTransition`` short-circuited (the prior reclaim
+      claim is still ours, where it shows a different claim, or
+      where the task has been reclaimed back to ``pending``;
+      and for the ``WrongToken`` short-circuit (the prior reclaim
       already errored our trial).
     - ``("conflict", banner)`` — orphan page; a different
       submission won the race (``ConflictingResubmission`` short-
@@ -382,24 +382,66 @@ def _retry_submit_with_readback(
     - ``("transport", banner)`` — orphan page; an
       implementation-illegal store state was observed during
       read-back (``read_submission`` returned ``None`` for a
-      ``submitted`` / ``completed`` / ``failed`` task).
+      ``submitted`` / ``completed`` / ``failed`` task) or the
+      read-back probe itself failed.
+
+    Exception classification (per
+    ``feedback_retry_readback_test_mocks.md`` rule 1):
+
+    - ``WrongToken`` and ``ConflictingResubmission`` are definitive
+      short-circuits. ``WrongToken`` only fires when
+      ``task.state == "claimed"`` with a non-matching token, which
+      a successful prior submit never produces (submit preserves
+      our token). ``ConflictingResubmission`` is the spec-defined
+      "different payload won" signal.
+    - ``IllegalTransition`` is **not** a definitive short-circuit:
+      it falls through to read-back. The store raises it when
+      ``task.state ∉ {"claimed", "submitted"}`` at call time,
+      which after a transport-indeterminate first attempt may
+      mean ``pending`` (we lost), ``completed``/``failed`` (we
+      won and the orchestrator already terminalized), or
+      ``submitted`` by another worker (conflict). Read-back
+      disambiguates.
+    - Other exceptions are retried with backoff; on exhaustion,
+      read-back resolves.
     """
     last_exc: BaseException | None = None
+    needs_readback = False
     for delay in _RETRY_DELAYS_S:
         try:
             store.submit(task_id, token, submission)
             return "ok", None
         except WrongToken as exc:
             return "auto", _wire_error_banner(exc)
-        except IllegalTransition as exc:
-            return "auto", _wire_error_banner(exc)
         except ConflictingResubmission as exc:
             return "conflict", _wire_error_banner(exc)
+        except IllegalTransition as exc:
+            last_exc = exc
+            needs_readback = True
+            break
         except Exception as exc:  # noqa: BLE001 — transport-shaped
             last_exc = exc
             time.sleep(delay)
 
-    # Retries exhausted with transport-shaped failures only. Reconcile.
+    if not needs_readback and last_exc is None:
+        # All retries returned cleanly is impossible (we'd return
+        # "ok" inside the loop). Defensive.
+        return "transport", "submit returned without exception or commit"
+
+    return _readback(
+        store=store, task_id=task_id, token=token, submission=submission, last_exc=last_exc
+    )
+
+
+def _readback(
+    *,
+    store: Any,
+    task_id: str,
+    token: str,
+    submission: ImplementSubmission,
+    last_exc: BaseException | None,
+) -> tuple[str, str | None]:
+    last_name = last_exc.__class__.__name__ if last_exc else "unknown"
     try:
         task = store.read_task(task_id)
     except Exception as exc:  # noqa: BLE001
@@ -408,13 +450,9 @@ def _retry_submit_with_readback(
             f"transport failure after retries; read-back failed: {exc.__class__.__name__}",
         )
     state = task.state
-    last_name = last_exc.__class__.__name__ if last_exc else "unknown"
     if state == "claimed":
         if task.claim is not None and task.claim.token == token:
-            return (
-                "auto",
-                f"transport failure after retries: {last_name}",
-            )
+            return ("auto", f"transport failure after retries: {last_name}")
         return "auto", "eden://error/wrong-token"
     if state in {"submitted", "completed", "failed"}:
         try:
@@ -436,10 +474,7 @@ def _retry_submit_with_readback(
             return "ok", None
         return "conflict", "eden://error/conflicting-resubmission"
     # state == "pending"
-    return (
-        "auto",
-        f"transport failure after retries; task reclaimed: {last_name}",
-    )
+    return ("auto", f"transport failure after retries; task reclaimed: {last_name}")
 
 
 def _render_draft(

--- a/reference/services/web-ui/src/eden_web_ui/routes/planner.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/planner.py
@@ -28,6 +28,7 @@ from eden_storage import (
     PlanSubmission,
     WrongToken,
 )
+from eden_storage.submissions import submissions_equivalent
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -322,15 +323,20 @@ def _retry_submit(
       ``eden://error/<name>`` (or a transport summary) suitable for
       surfacing to the user.
 
-    Definitive store-domain errors (``WrongToken``,
-    ``ConflictingResubmission``, ``InvalidPrecondition``,
-    ``IllegalTransition``) are not retried — retrying any of them
-    cannot change the outcome and any further attempt would just
-    return the same error or hide an actually-committed prior
-    attempt. Anything else (``DispatchError`` without a known
-    subclass, or a raw transport exception from the wire client
-    such as ``httpx.HTTPError``) is treated as transport-shaped
-    and retried.
+    Exception classification (per
+    ``feedback_retry_readback_test_mocks.md`` rule 1):
+
+    - ``WrongToken``, ``ConflictingResubmission``, and
+      ``InvalidPrecondition`` are definitive short-circuits;
+      retrying them cannot change the outcome.
+    - ``IllegalTransition`` is **not** definitive: it falls
+      through to a read-back that distinguishes "we won; the
+      orchestrator already terminalized" (success) from "we
+      lost; task reclaimed or different submission won"
+      (orphan). Treating it as a definitive orphan would
+      mis-classify a successful submit whose response was lost.
+    - Other exceptions (transport-shaped) are retried with
+      backoff; on exhaustion, the read-back resolves.
 
     On any definitive failure, the caller renders the orphan page
     rather than a "preserve input + claim again" form. Reasoning:
@@ -342,23 +348,56 @@ def _retry_submit(
     errors, where no store mutation has happened yet.
     """
     last_exc: BaseException | None = None
+    needs_readback = False
     for delay in _RETRY_DELAYS_S:
         try:
             store.submit(task_id, token, submission)
             return True, None
-        except (
-            WrongToken,
-            ConflictingResubmission,
-            InvalidPrecondition,
-            IllegalTransition,
-        ) as exc:
+        except (WrongToken, ConflictingResubmission, InvalidPrecondition) as exc:
             return False, _wire_error_banner(exc)
+        except IllegalTransition as exc:
+            last_exc = exc
+            needs_readback = True
+            break
         except Exception as exc:  # noqa: BLE001 — transport-shaped or unknown
             last_exc = exc
             time.sleep(delay)
-    if last_exc is None:
-        return True, None
-    return False, f"transport failure after retries: {last_exc.__class__.__name__}"
+
+    # Either retries exhausted with transport-shape failures, or
+    # IllegalTransition broke us out of the loop. Either way,
+    # read-back disambiguates: an equivalent prior submission means
+    # we won and the response was lost in transit; anything else is
+    # orphan.
+    if needs_readback or last_exc is not None:
+        try:
+            task = store.read_task(task_id)
+        except Exception as exc:  # noqa: BLE001
+            return (
+                False,
+                "transport failure after retries; "
+                f"read-back failed: {exc.__class__.__name__}",
+            )
+        if task.state in {"submitted", "completed", "failed"}:
+            try:
+                prior = store.read_submission(task_id)
+            except Exception as exc:  # noqa: BLE001
+                return (
+                    False,
+                    "transport failure after retries; "
+                    f"read-submission failed: {exc.__class__.__name__}",
+                )
+            if prior is not None and submissions_equivalent(prior, submission):
+                # We won — the orchestrator already accepted (or
+                # rejected) our equivalent prior submission and the
+                # transport just lost the response.
+                return True, None
+            # state moved past submitted with a different submission
+            # → orphan conflict.
+            return False, "eden://error/conflicting-resubmission"
+        last_name = last_exc.__class__.__name__ if last_exc else "unknown"
+        return False, f"transport failure after retries: {last_name}"
+
+    return True, None
 
 
 def _make_proposal(

--- a/reference/services/web-ui/tests/test_implementer_partial_write.py
+++ b/reference/services/web-ui/tests/test_implementer_partial_write.py
@@ -30,6 +30,7 @@ from eden_dispatch import sweep_expired_claims
 from eden_git import GitRepo
 from eden_storage import (
     ConflictingResubmission,
+    IllegalTransition,
     ImplementSubmission,
     InMemoryStore,
     WrongToken,
@@ -480,3 +481,158 @@ def _build_submission(child_sha: str) -> ImplementSubmission:
     return ImplementSubmission(
         status="success", trial_id="trial-x", commit_sha=child_sha
     )
+
+
+class TestPhase3IllegalTransitionReadback:
+    """`IllegalTransition` feeds read-back, not a definitive short-circuit.
+
+    These three sub-cases cover the §K-2 fix to chunk 9c: the
+    chunk-9c implementer module originally treated
+    ``IllegalTransition`` as a definitive auto-orphan, which
+    mis-classifies the "we won, response lost, orchestrator
+    already terminalized" sequence. The fix routes
+    ``IllegalTransition`` to read-back; the read-back's three
+    branches (state==pending, state==completed with equivalent
+    prior, state==completed with non-equivalent prior) cover the
+    actual outcomes.
+    """
+
+    def test_pending_after_illegal_transition_renders_auto_orphan(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+    ) -> None:
+        task_id, child_sha = _claim_and_prep(
+            signed_in_impl_client, store, bare_repo, base_sha, slug="ita"
+        )
+        # Reclaim the task ourselves so its state is pending; the
+        # route's submit will then raise IllegalTransition. Read-back
+        # finds state==pending → orphan auto.
+        store.reclaim(task_id, "operator")
+        csrf = get_csrf(signed_in_impl_client)
+        resp = _post_form(
+            signed_in_impl_client,
+            f"/implementer/{task_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("commit_sha", child_sha),
+            ],
+        )
+        assert resp.status_code == 502
+        assert "auto-recovers" in resp.text
+        # Banner mentions reclaim, distinguishing this from "we won"
+        # (sub-case b below) which renders the success page.
+        assert "task reclaimed" in resp.text
+
+    def test_completed_with_equivalent_prior_renders_success(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+        monkeypatch,
+    ) -> None:
+        """The lens that flips the chunk-9c short-circuit bug to correct.
+
+        Models "our first submit attempt committed, transport lost
+        the response, the orchestrator already terminalized to
+        completed; our retry observes IllegalTransition." The fix
+        routes IllegalTransition to read-back; read-back finds an
+        equivalent prior submission → success page.
+        """
+        task_id, child_sha = _claim_and_prep(
+            signed_in_impl_client, store, bare_repo, base_sha, slug="itb"
+        )
+        original_submit = store.submit
+
+        def fake_submit(task_id_, token, submission):
+            # Commit our submission, accept it (state -> completed),
+            # then raise IllegalTransition to simulate "response was
+            # lost; we re-tried and saw a state the store now
+            # rejects." Read-back must find our equivalent committed
+            # submission and render success.
+            original_submit(task_id_, token, submission)
+            store.accept(task_id_)
+            raise IllegalTransition("simulated post-terminalization retry")
+
+        monkeypatch.setattr(store, "submit", fake_submit)
+        csrf = get_csrf(signed_in_impl_client)
+        resp = _post_form(
+            signed_in_impl_client,
+            f"/implementer/{task_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("commit_sha", child_sha),
+            ],
+        )
+        # SUCCESS — this is the chunk-9c §K-2 bug, fixed.
+        assert resp.status_code == 200
+        assert child_sha in resp.text
+
+    def test_completed_with_non_equivalent_prior_renders_conflict(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+        monkeypatch,
+    ) -> None:
+        """IllegalTransition + read-back finds a different submission → conflict."""
+        from eden_contracts import ImplementPayload, ImplementTask
+
+        task_id, child_sha = _claim_and_prep(
+            signed_in_impl_client, store, bare_repo, base_sha, slug="itc"
+        )
+        synthetic_task = ImplementTask(
+            task_id=task_id,
+            kind="implement",
+            state="completed",
+            payload=ImplementPayload(proposal_id="proposal-itc"),
+            created_at="2026-04-24T11:00:00.000Z",
+            updated_at="2026-04-24T13:00:00.000Z",
+        )
+        # A different worker's submission would have a different
+        # trial_id; equivalence keys off (status, trial_id, commit_sha).
+        non_equiv_prior = ImplementSubmission(
+            status="success",
+            trial_id="trial-other-worker",
+            commit_sha=child_sha,
+        )
+
+        def fake_submit(*a, **k):
+            raise IllegalTransition("task already terminal")
+
+        # Patch read_task to return synthetic AFTER the route's
+        # pre-submit reads run. Easiest: use a one-shot wrapper that
+        # arms the patch on the first store.submit call.
+        original_read_task = store.read_task
+        original_read_submission = store.read_submission
+
+        def arm_then_raise(*a, **k):
+            monkeypatch.setattr(store, "read_task", lambda tid: synthetic_task)
+            monkeypatch.setattr(
+                store, "read_submission", lambda tid: non_equiv_prior
+            )
+            raise IllegalTransition("task already terminal")
+
+        monkeypatch.setattr(store, "submit", arm_then_raise)
+        csrf = get_csrf(signed_in_impl_client)
+        resp = _post_form(
+            signed_in_impl_client,
+            f"/implementer/{task_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("commit_sha", child_sha),
+            ],
+        )
+        # Restore so subsequent fixture cleanup works.
+        monkeypatch.setattr(store, "read_task", original_read_task)
+        monkeypatch.setattr(store, "read_submission", original_read_submission)
+        assert resp.status_code == 502
+        assert "conflicting-resubmission" in resp.text
+        assert "operator intervention" in resp.text

--- a/reference/services/web-ui/tests/test_planner_flow.py
+++ b/reference/services/web-ui/tests/test_planner_flow.py
@@ -414,12 +414,20 @@ class TestDefinitiveSubmitErrors:
         assert "eden://error/wrong-token" in resp.text
         assert len(store.list_proposals(state="ready")) == 1
 
-    def test_illegal_transition_lands_on_orphan_with_banner(
+    def test_illegal_transition_feeds_readback(
         self,
         signed_in_client: TestClient,
         store: InMemoryStore,
         monkeypatch,
     ) -> None:
+        """``IllegalTransition`` no longer short-circuits to orphan.
+
+        It now falls through to read-back. With the underlying task
+        still claimed by us, read-back surfaces a transport-flavored
+        banner naming ``IllegalTransition`` rather than the raw
+        wire-error string. The "we won" sub-case is covered in the
+        IllegalTransitionReadback class below.
+        """
         from eden_storage import IllegalTransition
 
         token = self._setup_claim(signed_in_client, store, "t-it")
@@ -430,7 +438,11 @@ class TestDefinitiveSubmitErrors:
         monkeypatch.setattr(store, "submit", fail)
         resp = self._submit(signed_in_client, "t-it", token)
         assert resp.status_code == 502
-        assert "eden://error/illegal-transition" in resp.text
+        # Old behavior asserted "eden://error/illegal-transition" but
+        # the new read-back-fed contract surfaces the exception class
+        # name in the transport banner.
+        assert "IllegalTransition" in resp.text
+        assert "eden://error/illegal-transition" not in resp.text
 
     def test_conflicting_resubmission_lands_on_orphan_with_banner(
         self,
@@ -467,6 +479,104 @@ class TestDefinitiveSubmitErrors:
         resp = self._submit(signed_in_client, "t-ip", token)
         assert resp.status_code == 502
         assert "eden://error/invalid-precondition" in resp.text
+
+
+class TestIllegalTransitionReadback:
+    """``IllegalTransition`` feeds read-back, not a definitive orphan.
+
+    Distinguishes "we won; orchestrator already terminalized" from
+    "we lost; different submission won." The chunk-9c implementer
+    module shipped this lens via §K-2 of the chunk-9d plan; the
+    planner gets the same fix here.
+    """
+
+    def _setup_claim(
+        self, client: TestClient, store: InMemoryStore, task_id: str
+    ) -> str:
+        store.create_plan_task(task_id)
+        token = get_csrf(client)
+        resp = client.post(
+            f"/planner/{task_id}/claim",
+            data={"csrf_token": token},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 303
+        return token
+
+    def _submit(
+        self, client: TestClient, task_id: str, csrf: str
+    ):
+        return client.post(
+            f"/planner/{task_id}/submit",
+            data={
+                "csrf_token": csrf,
+                "status": "success",
+                "slug": "feat-rb",
+                "priority": "1.0",
+                "parent_commits": "a" * 40,
+                "rationale": "rationale",
+            },
+        )
+
+    def test_completed_with_equivalent_prior_renders_success(
+        self,
+        signed_in_client: TestClient,
+        store: InMemoryStore,
+        monkeypatch,
+    ) -> None:
+        """We won: submit committed, orchestrator terminalized, retry hit IllegalTransition."""
+        from eden_storage import IllegalTransition
+
+        csrf = self._setup_claim(signed_in_client, store, "t-itb")
+        original_submit = store.submit
+
+        def fake_submit(task_id_, token, submission):
+            # Commit, accept (state -> completed), then raise
+            # IllegalTransition simulating "response was lost; we
+            # retried and saw a state the store rejects."
+            original_submit(task_id_, token, submission)
+            store.accept(task_id_)
+            raise IllegalTransition("simulated post-terminalization retry")
+
+        monkeypatch.setattr(store, "submit", fake_submit)
+        resp = self._submit(signed_in_client, "t-itb", csrf)
+        # SUCCESS, not orphan — this is the planner-side §K-2 fix.
+        assert resp.status_code == 200
+        assert "feat-rb" in resp.text or "submitted" in resp.text.lower()
+
+    def test_completed_with_non_equivalent_prior_renders_orphan(
+        self,
+        signed_in_client: TestClient,
+        store: InMemoryStore,
+        monkeypatch,
+    ) -> None:
+        """Different submission won the race; read-back finds non-equivalent."""
+        from eden_contracts import PlanPayload, PlanTask
+        from eden_storage import IllegalTransition, PlanSubmission
+
+        csrf = self._setup_claim(signed_in_client, store, "t-itc")
+        synthetic_task = PlanTask(
+            task_id="t-itc",
+            kind="plan",
+            state="completed",
+            payload=PlanPayload(experiment_id=store.experiment_id),
+            created_at="2026-04-24T11:00:00.000Z",
+            updated_at="2026-04-24T13:00:00.000Z",
+        )
+        non_equiv_prior = PlanSubmission(
+            status="success", proposal_ids=("proposal-other-worker",)
+        )
+
+        def fake_submit(*a, **k):
+            raise IllegalTransition("task already terminal")
+
+        monkeypatch.setattr(store, "submit", fake_submit)
+        monkeypatch.setattr(store, "read_task", lambda tid: synthetic_task)
+        monkeypatch.setattr(store, "read_submission", lambda tid: non_equiv_prior)
+
+        resp = self._submit(signed_in_client, "t-itc", csrf)
+        assert resp.status_code == 502
+        assert "conflicting-resubmission" in resp.text
 
 
 class TestRetryBeforeOrphan:


### PR DESCRIPTION
## Summary

- Fixes a class of bug in chunks 1 (planner) and 9c (implementer): both retry-before-orphan helpers treated `IllegalTransition` as a definitive short-circuit to the orphan page, mis-classifying "we won, response lost" sequences as "we lost." Routes `IllegalTransition` through read-back so the actual state determines the outcome (success / conflict / auto-orphan).
- Adds the planner its first read-back implementation (it previously only had retry-then-orphan). The implementer's `_retry_submit_with_readback` is refactored to extract `_readback` and have `IllegalTransition` fall through.
- Chunk 9d's evaluator already shipped with the correct behavior; this brings the other two roles in line.

Tests:
- 3 new sub-cases in `test_implementer_partial_write.py::TestPhase3IllegalTransitionReadback` (I-a state==pending; I-b equivalent → success; I-c non-equivalent → conflict).
- 2 new sub-cases in `test_planner_flow.py::TestIllegalTransitionReadback`.
- Pre-existing `test_illegal_transition_lands_on_orphan_with_banner` updated to the new contract (renamed `test_illegal_transition_feeds_readback`).

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run pyright` clean
- [x] `uv run pytest -q` — 559 passed
- [x] `uv run pytest -m e2e` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)