### PR TITLE
Track deferred items via TODO comments linking GitHub issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,11 @@ jobs:
         working-directory: reference/compose
         run: bash healthcheck/smoke-subprocess.sh
 
+  # TODO(eden#38): bump branch protection to require this job once it
+  # has stayed clean on main for ~2 weeks since 2026-05-01. If this
+  # job flakes on main between now and then, leave a comment on
+  # issue #38 with the run URL and the failure mode so the bump can
+  # account for it.
   compose-smoke-subprocess-docker:
     name: compose-smoke-subprocess-docker
     runs-on: ubuntu-latest
@@ -262,6 +267,11 @@ jobs:
           EDEN_TEST_POSTGRES_DSN: postgresql://postgres:postgres@localhost:5432/postgres
         run: uv run pytest -q reference/packages/eden-storage/tests
 
+  # TODO(eden#38): bump branch protection to require this job once it
+  # has stayed clean on main for ~2 weeks since 2026-05-01. If this
+  # job flakes on main between now and then, leave a comment on
+  # issue #38 with the run URL and the failure mode so the bump can
+  # account for it.
   conformance:
     name: conformance
     runs-on: ubuntu-latest

--- a/reference/services/orchestrator/tests/test_subprocess_e2e.py
+++ b/reference/services/orchestrator/tests/test_subprocess_e2e.py
@@ -4,6 +4,15 @@ Mirrors ``test_e2e.py`` but runs each worker host with
 ``--mode subprocess`` and the fixture's ``plan.py`` /
 ``implement.py`` / ``eval.py`` scripts. Asserts the same final
 3-trial-success shape against the bare repo.
+
+# TODO(eden#39): this test flakes ~30% locally because the
+# orchestrator's default ``--max-quiescent-iterations 3 ×
+# --poll-interval 0.1 = 0.3s`` quiescence tolerance is shorter
+# than the subprocess-mode worker startup window. Bumping the
+# tolerance triggers a deeper bug (task-store-server stalls on
+# ``list_trials`` after ~8s of orchestrator runtime). Investigation
+# in progress; if this test flakes on CI, leave a comment on issue
+# #39 with the run URL.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Adds TODO comments cross-referencing two newly-filed tracking issues:

- **[#38 — bump branch protection](https://github.com/ealt/eden/issues/38)**: TODO comments next to the `conformance` and `compose-smoke-subprocess-docker` job blocks in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). The bump should land after ~2 weeks of clean runs on main.
- **[#39 — orchestrator+server stall investigation](https://github.com/ealt/eden/issues/39)**: TODO comment in the [`test_subprocess_e2e.py`](reference/services/orchestrator/tests/test_subprocess_e2e.py) docstring documenting the ~30% local flake rate and the deeper bug uncovered while trying to fix it (httpx ReadTimeout on `list_trials` after ~8s of orchestrator runtime).

Each TODO explicitly asks future contributors to leave a comment on the linked issue if they hit related failures — keeps the issue's context current without a separate reminder mechanism.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses (YAML still valid).
- [x] `uv run pyright reference/services/orchestrator/tests/test_subprocess_e2e.py` clean (docstring change only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)