### PR TITLE
Apply eden#39 pipe-fill fix preventatively to web-ui e2e tests

### DIFF
--- a/reference/services/web-ui/tests/test_admin_e2e.py
+++ b/reference/services/web-ui/tests/test_admin_e2e.py
@@ -38,30 +38,37 @@ _TASK_STORE_RE = re.compile(r"^EDEN_TASK_STORE_LISTENING\s+(.*)$")
 _WEB_UI_RE = re.compile(r"^EDEN_WEB_UI_LISTENING\s+(.*)$")
 
 
-def _spawn(args: list[str]) -> subprocess.Popen:
+def _spawn(args: list[str], log_path: Path) -> subprocess.Popen:
+    # See eden#39: undrained subprocess.PIPE handles fill the 64 KiB
+    # pipe buffer and wedge the writer's async event loop.
     return subprocess.Popen(
         [sys.executable, "-m", *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+        stdout=open(log_path, "wb"),  # noqa: SIM115 — handle owned by Popen
+        stderr=subprocess.STDOUT,
     )
 
 
 def _read_port(
-    proc: subprocess.Popen, pattern: re.Pattern[str], timeout: float = 10.0
+    log_path: Path,
+    proc: subprocess.Popen,
+    pattern: re.Pattern[str],
+    timeout: float = 10.0,
 ) -> int:
     deadline = time.monotonic() + timeout
-    assert proc.stdout is not None
     while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            if proc.poll() is not None:
-                raise RuntimeError(f"subprocess exited early rc={proc.returncode}")
-            continue
-        m = pattern.match(line.strip())
-        if m is not None:
-            kv = dict(p.split("=", 1) for p in m.group(1).split())
-            return int(kv["port"])
+        if log_path.exists():
+            try:
+                content = log_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                content = ""
+            for line in content.splitlines():
+                m = pattern.match(line.strip())
+                if m is not None:
+                    kv = dict(p.split("=", 1) for p in m.group(1).split())
+                    return int(kv["port"])
+        if proc.poll() is not None:
+            raise RuntimeError(f"subprocess exited early rc={proc.returncode}")
+        time.sleep(0.05)
     raise RuntimeError("subprocess did not announce its port in time")
 
 
@@ -76,16 +83,20 @@ def _terminate(proc: subprocess.Popen) -> None:
         proc.wait(timeout=2)
 
 
-def _dump_stderr(procs: dict[str, subprocess.Popen]) -> str:
+def _dump_logs(procs_logs: dict[str, tuple[subprocess.Popen, Path]]) -> str:
     parts = []
-    for name, p in procs.items():
-        stderr = ""
-        if p.stderr is not None:
-            try:
-                stderr = p.stderr.read() or ""
-            except Exception as exc:  # noqa: BLE001
-                stderr = f"<failed to read stderr: {exc!r}>"
-        parts.append(f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{stderr}\n")
+    for name, (p, log_path) in procs_logs.items():
+        try:
+            content = (
+                log_path.read_text(encoding="utf-8", errors="replace")
+                if log_path.exists()
+                else ""
+            )
+        except OSError as exc:
+            content = f"<failed to read {log_path}: {exc!r}>"
+        parts.append(
+            f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{content}\n"
+        )
     return "\n".join(parts)
 
 
@@ -97,7 +108,10 @@ def test_admin_reclaim_round_trip(tmp_path: Path) -> None:
     artifacts_dir.mkdir()
     experiment_id = "exp-admin-e2e"
     token = "admin-e2e-token"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
 
+    server_log = logs_dir / "server.log"
     server = _spawn(
         [
             "eden_task_store_server",
@@ -115,11 +129,13 @@ def test_admin_reclaim_round_trip(tmp_path: Path) -> None:
             token,
             "--subscribe-timeout",
             "1.0",
-        ]
+        ],
+        server_log,
     )
-    server_port = _read_port(server, _TASK_STORE_RE)
+    server_port = _read_port(server_log, server, _TASK_STORE_RE)
     task_store_url = f"http://127.0.0.1:{server_port}"
 
+    web_ui_log = logs_dir / "web-ui.log"
     web_ui = _spawn(
         [
             "eden_web_ui",
@@ -143,12 +159,16 @@ def test_admin_reclaim_round_trip(tmp_path: Path) -> None:
             "0",
             "--claim-ttl-seconds",
             "60",
-        ]
+        ],
+        web_ui_log,
     )
-    web_port = _read_port(web_ui, _WEB_UI_RE)
+    web_port = _read_port(web_ui_log, web_ui, _WEB_UI_RE)
     web_url = f"http://127.0.0.1:{web_port}"
 
-    procs = {"task-store-server": server, "web-ui": web_ui}
+    procs_logs = {
+        "task-store-server": (server, server_log),
+        "web-ui": (web_ui, web_ui_log),
+    }
 
     try:
         from eden_wire import StoreClient
@@ -194,7 +214,7 @@ def test_admin_reclaim_round_trip(tmp_path: Path) -> None:
             if resp.status_code != 303:
                 pytest.fail(
                     f"reclaim returned {resp.status_code}: {resp.text}\n"
-                    + _dump_stderr(procs)
+                    + _dump_logs(procs_logs)
                 )
             assert "?reclaimed=ok" in resp.headers["location"]
 
@@ -213,5 +233,5 @@ def test_admin_reclaim_round_trip(tmp_path: Path) -> None:
         finally:
             verify.close()
     finally:
-        _terminate(web_ui)
-        _terminate(server)
+        for p, _ in procs_logs.values():
+            _terminate(p)

--- a/reference/services/web-ui/tests/test_e2e_real_subprocess.py
+++ b/reference/services/web-ui/tests/test_e2e_real_subprocess.py
@@ -41,12 +41,13 @@ FIXTURE_CONFIG = (
 )
 
 
-def _spawn(args: list[str]) -> subprocess.Popen:
+def _spawn(args: list[str], log_path: Path) -> subprocess.Popen:
+    # See eden#39: undrained subprocess.PIPE handles fill the 64 KiB
+    # pipe buffer and wedge the writer's async event loop.
     return subprocess.Popen(
         [sys.executable, "-m", *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+        stdout=open(log_path, "wb"),  # noqa: SIM115 — handle owned by Popen
+        stderr=subprocess.STDOUT,
     )
 
 
@@ -55,22 +56,28 @@ _WEB_UI_RE = re.compile(r"^EDEN_WEB_UI_LISTENING\s+(.*)$")
 
 
 def _read_announcement(
-    proc: subprocess.Popen, pattern: re.Pattern[str], timeout: float = 10.0
+    log_path: Path,
+    proc: subprocess.Popen,
+    pattern: re.Pattern[str],
+    timeout: float = 10.0,
 ) -> int:
     deadline = time.monotonic() + timeout
-    assert proc.stdout is not None
     while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            if proc.poll() is not None:
-                raise RuntimeError(
-                    f"subprocess exited early with code {proc.returncode}"
-                )
-            continue
-        m = pattern.match(line.strip())
-        if m is not None:
-            kv = dict(p.split("=", 1) for p in m.group(1).split())
-            return int(kv["port"])
+        if log_path.exists():
+            try:
+                content = log_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                content = ""
+            for line in content.splitlines():
+                m = pattern.match(line.strip())
+                if m is not None:
+                    kv = dict(p.split("=", 1) for p in m.group(1).split())
+                    return int(kv["port"])
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"subprocess exited early with code {proc.returncode}"
+            )
+        time.sleep(0.05)
     raise RuntimeError("subprocess did not announce its port in time")
 
 
@@ -85,16 +92,20 @@ def _terminate(proc: subprocess.Popen, timeout: float = 5.0) -> None:
         proc.wait(timeout=2)
 
 
-def _dump_stderr(procs: dict[str, subprocess.Popen]) -> str:
+def _dump_logs(procs_logs: dict[str, tuple[subprocess.Popen, Path]]) -> str:
     parts = []
-    for name, p in procs.items():
-        stderr = ""
-        if p.stderr is not None:
-            try:
-                stderr = p.stderr.read() or ""
-            except Exception as exc:  # noqa: BLE001
-                stderr = f"<failed to read stderr: {exc!r}>"
-        parts.append(f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{stderr}\n")
+    for name, (p, log_path) in procs_logs.items():
+        try:
+            content = (
+                log_path.read_text(encoding="utf-8", errors="replace")
+                if log_path.exists()
+                else ""
+            )
+        except OSError as exc:
+            content = f"<failed to read {log_path}: {exc!r}>"
+        parts.append(
+            f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{content}\n"
+        )
     return "\n".join(parts)
 
 
@@ -105,7 +116,10 @@ def test_planner_full_flow_through_ui(tmp_path: Path) -> None:
     artifacts_dir = tmp_path / "artifacts"
     experiment_id = "exp-web-ui-e2e"
     token = "e2e-test-token"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
 
+    server_log = logs_dir / "server.log"
     server = _spawn(
         [
             "eden_task_store_server",
@@ -123,11 +137,13 @@ def test_planner_full_flow_through_ui(tmp_path: Path) -> None:
             token,
             "--subscribe-timeout",
             "1.0",
-        ]
+        ],
+        server_log,
     )
-    server_port = _read_announcement(server, _TASK_STORE_RE)
+    server_port = _read_announcement(server_log, server, _TASK_STORE_RE)
     task_store_url = f"http://127.0.0.1:{server_port}"
 
+    web_ui_log = logs_dir / "web-ui.log"
     web_ui = _spawn(
         [
             "eden_web_ui",
@@ -151,12 +167,16 @@ def test_planner_full_flow_through_ui(tmp_path: Path) -> None:
             "0",
             "--claim-ttl-seconds",
             "60",
-        ]
+        ],
+        web_ui_log,
     )
-    web_port = _read_announcement(web_ui, _WEB_UI_RE)
+    web_port = _read_announcement(web_ui_log, web_ui, _WEB_UI_RE)
     web_url = f"http://127.0.0.1:{web_port}"
 
-    procs = {"task-store-server": server, "web-ui": web_ui}
+    procs_logs = {
+        "task-store-server": (server, server_log),
+        "web-ui": (web_ui, web_ui_log),
+    }
 
     try:
         # Seed one plan task via the wire StoreClient.
@@ -219,12 +239,12 @@ def test_planner_full_flow_through_ui(tmp_path: Path) -> None:
             if resp.status_code != 200:
                 pytest.fail(
                     f"submit returned {resp.status_code}: {resp.text}\n"
-                    + _dump_stderr(procs)
+                    + _dump_logs(procs_logs)
                 )
             assert "submitted" in resp.text.lower()
 
         # Tear down processes before reading SQLite (release file lock).
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)
 
         store = SqliteStore(
@@ -246,7 +266,7 @@ def test_planner_full_flow_through_ui(tmp_path: Path) -> None:
         finally:
             store.close()
     finally:
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)
 
 
@@ -275,7 +295,10 @@ def test_stranded_claim_recovered_by_orchestrator_loop(tmp_path: Path) -> None:
 
     experiment_id = "exp-strand"
     token = "strand-token"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
 
+    server_log = logs_dir / "server.log"
     server = _spawn(
         [
             "eden_task_store_server",
@@ -293,11 +316,13 @@ def test_stranded_claim_recovered_by_orchestrator_loop(tmp_path: Path) -> None:
             token,
             "--subscribe-timeout",
             "1.0",
-        ]
+        ],
+        server_log,
     )
-    server_port = _read_announcement(server, _TASK_STORE_RE)
+    server_port = _read_announcement(server_log, server, _TASK_STORE_RE)
     task_store_url = f"http://127.0.0.1:{server_port}"
 
+    web_ui_log = logs_dir / "web-ui.log"
     web_ui = _spawn(
         [
             "eden_web_ui",
@@ -321,14 +346,15 @@ def test_stranded_claim_recovered_by_orchestrator_loop(tmp_path: Path) -> None:
             "0",
             "--claim-ttl-seconds",
             "1",
-        ]
+        ],
+        web_ui_log,
     )
-    web_port = _read_announcement(web_ui, _WEB_UI_RE)
+    web_port = _read_announcement(web_ui_log, web_ui, _WEB_UI_RE)
     web_url = f"http://127.0.0.1:{web_port}"
 
-    procs: dict[str, subprocess.Popen] = {
-        "task-store-server": server,
-        "web-ui": web_ui,
+    procs_logs: dict[str, tuple[subprocess.Popen, Path]] = {
+        "task-store-server": (server, server_log),
+        "web-ui": (web_ui, web_ui_log),
     }
 
     try:
@@ -367,6 +393,7 @@ def test_stranded_claim_recovered_by_orchestrator_loop(tmp_path: Path) -> None:
         # Now spawn the orchestrator with NO plan tasks; its loop runs
         # sweep_expired_claims once per iteration, sees no other
         # progress, and quiesces.
+        orchestrator_log = logs_dir / "orchestrator.log"
         orchestrator = _spawn(
             [
                 "eden_orchestrator",
@@ -384,23 +411,24 @@ def test_stranded_claim_recovered_by_orchestrator_loop(tmp_path: Path) -> None:
                 "2",
                 "--poll-interval",
                 "0.1",
-            ]
+            ],
+            orchestrator_log,
         )
-        procs["orchestrator"] = orchestrator
+        procs_logs["orchestrator"] = (orchestrator, orchestrator_log)
         try:
             rc = orchestrator.wait(timeout=30)
         except subprocess.TimeoutExpired:
-            for p in procs.values():
+            for p, _ in procs_logs.values():
                 _terminate(p)
             pytest.fail(
-                "orchestrator did not quiesce within 30s. Stderr:\n"
-                + _dump_stderr(procs)
+                "orchestrator did not quiesce within 30s. Output:\n"
+                + _dump_logs(procs_logs)
             )
         if rc != 0:
-            for p in procs.values():
+            for p, _ in procs_logs.values():
                 _terminate(p)
             pytest.fail(
-                f"orchestrator exited {rc}. Stderr:\n" + _dump_stderr(procs)
+                f"orchestrator exited {rc}. Output:\n" + _dump_logs(procs_logs)
             )
 
         # Verify state via a separate StoreClient.
@@ -423,5 +451,5 @@ def test_stranded_claim_recovered_by_orchestrator_loop(tmp_path: Path) -> None:
         finally:
             client.close()
     finally:
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)

--- a/reference/services/web-ui/tests/test_evaluator_e2e.py
+++ b/reference/services/web-ui/tests/test_evaluator_e2e.py
@@ -42,28 +42,37 @@ _TASK_STORE_RE = re.compile(r"^EDEN_TASK_STORE_LISTENING\s+(.*)$")
 _WEB_UI_RE = re.compile(r"^EDEN_WEB_UI_LISTENING\s+(.*)$")
 
 
-def _spawn(args: list[str]) -> subprocess.Popen:
+def _spawn(args: list[str], log_path: Path) -> subprocess.Popen:
+    # See eden#39: undrained subprocess.PIPE handles fill the 64 KiB
+    # pipe buffer and wedge the writer's async event loop.
     return subprocess.Popen(
         [sys.executable, "-m", *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+        stdout=open(log_path, "wb"),  # noqa: SIM115 — handle owned by Popen
+        stderr=subprocess.STDOUT,
     )
 
 
-def _read_port(proc: subprocess.Popen, pattern: re.Pattern[str], timeout: float = 10.0) -> int:
+def _read_port(
+    log_path: Path,
+    proc: subprocess.Popen,
+    pattern: re.Pattern[str],
+    timeout: float = 10.0,
+) -> int:
     deadline = time.monotonic() + timeout
-    assert proc.stdout is not None
     while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            if proc.poll() is not None:
-                raise RuntimeError(f"subprocess exited early rc={proc.returncode}")
-            continue
-        m = pattern.match(line.strip())
-        if m is not None:
-            kv = dict(p.split("=", 1) for p in m.group(1).split())
-            return int(kv["port"])
+        if log_path.exists():
+            try:
+                content = log_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                content = ""
+            for line in content.splitlines():
+                m = pattern.match(line.strip())
+                if m is not None:
+                    kv = dict(p.split("=", 1) for p in m.group(1).split())
+                    return int(kv["port"])
+        if proc.poll() is not None:
+            raise RuntimeError(f"subprocess exited early rc={proc.returncode}")
+        time.sleep(0.05)
     raise RuntimeError("subprocess did not announce its port in time")
 
 
@@ -78,16 +87,20 @@ def _terminate(proc: subprocess.Popen) -> None:
         proc.wait(timeout=2)
 
 
-def _dump_stderr(procs: dict[str, subprocess.Popen]) -> str:
+def _dump_logs(procs_logs: dict[str, tuple[subprocess.Popen, Path]]) -> str:
     parts = []
-    for name, p in procs.items():
-        stderr = ""
-        if p.stderr is not None:
-            try:
-                stderr = p.stderr.read() or ""
-            except Exception as exc:  # noqa: BLE001
-                stderr = f"<failed to read stderr: {exc!r}>"
-        parts.append(f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{stderr}\n")
+    for name, (p, log_path) in procs_logs.items():
+        try:
+            content = (
+                log_path.read_text(encoding="utf-8", errors="replace")
+                if log_path.exists()
+                else ""
+            )
+        except OSError as exc:
+            content = f"<failed to read {log_path}: {exc!r}>"
+        parts.append(
+            f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{content}\n"
+        )
     return "\n".join(parts)
 
 
@@ -99,7 +112,10 @@ def test_evaluator_full_flow_through_ui(tmp_path: Path) -> None:
     artifacts_dir.mkdir()
     experiment_id = "exp-eval-e2e"
     token = "eval-e2e-token"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
 
+    server_log = logs_dir / "server.log"
     server = _spawn(
         [
             "eden_task_store_server",
@@ -117,11 +133,13 @@ def test_evaluator_full_flow_through_ui(tmp_path: Path) -> None:
             token,
             "--subscribe-timeout",
             "1.0",
-        ]
+        ],
+        server_log,
     )
-    server_port = _read_port(server, _TASK_STORE_RE)
+    server_port = _read_port(server_log, server, _TASK_STORE_RE)
     task_store_url = f"http://127.0.0.1:{server_port}"
 
+    web_ui_log = logs_dir / "web-ui.log"
     web_ui = _spawn(
         [
             "eden_web_ui",
@@ -145,12 +163,16 @@ def test_evaluator_full_flow_through_ui(tmp_path: Path) -> None:
             "0",
             "--claim-ttl-seconds",
             "60",
-        ]
+        ],
+        web_ui_log,
     )
-    web_port = _read_port(web_ui, _WEB_UI_RE)
+    web_port = _read_port(web_ui_log, web_ui, _WEB_UI_RE)
     web_url = f"http://127.0.0.1:{web_port}"
 
-    procs = {"task-store-server": server, "web-ui": web_ui}
+    procs_logs = {
+        "task-store-server": (server, server_log),
+        "web-ui": (web_ui, web_ui_log),
+    }
 
     try:
         # Seed: ready proposal + implement task; drive it to a
@@ -244,11 +266,11 @@ def test_evaluator_full_flow_through_ui(tmp_path: Path) -> None:
             if resp.status_code != 200:
                 pytest.fail(
                     f"submit returned {resp.status_code}: {resp.text}\n"
-                    + _dump_stderr(procs)
+                    + _dump_logs(procs_logs)
                 )
             assert "0.875" in resp.text
 
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)
 
         store = SqliteStore(
@@ -268,5 +290,5 @@ def test_evaluator_full_flow_through_ui(tmp_path: Path) -> None:
         finally:
             store.close()
     finally:
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)

--- a/reference/services/web-ui/tests/test_implementer_e2e.py
+++ b/reference/services/web-ui/tests/test_implementer_e2e.py
@@ -45,28 +45,39 @@ _E2E_IDENTITY = Identity(name="EDEN E2E", email="e2e@eden.invalid")
 _E2E_DATE = "2026-04-24T12:00:00+00:00"
 
 
-def _spawn(args: list[str]) -> subprocess.Popen:
+def _spawn(args: list[str], log_path: Path) -> subprocess.Popen:
+    # See eden#39: undrained subprocess.PIPE handles fill the 64 KiB
+    # pipe buffer and wedge the writer's async event loop on a
+    # blocking log call. Per-process log files preserve diagnostics
+    # without back-pressure.
     return subprocess.Popen(
         [sys.executable, "-m", *args],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+        stdout=open(log_path, "wb"),  # noqa: SIM115 — handle owned by Popen
+        stderr=subprocess.STDOUT,
     )
 
 
-def _read_port(proc: subprocess.Popen, pattern: re.Pattern[str], timeout: float = 10.0) -> int:
+def _read_port(
+    log_path: Path,
+    proc: subprocess.Popen,
+    pattern: re.Pattern[str],
+    timeout: float = 10.0,
+) -> int:
     deadline = time.monotonic() + timeout
-    assert proc.stdout is not None
     while time.monotonic() < deadline:
-        line = proc.stdout.readline()
-        if not line:
-            if proc.poll() is not None:
-                raise RuntimeError(f"subprocess exited early rc={proc.returncode}")
-            continue
-        m = pattern.match(line.strip())
-        if m is not None:
-            kv = dict(p.split("=", 1) for p in m.group(1).split())
-            return int(kv["port"])
+        if log_path.exists():
+            try:
+                content = log_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                content = ""
+            for line in content.splitlines():
+                m = pattern.match(line.strip())
+                if m is not None:
+                    kv = dict(p.split("=", 1) for p in m.group(1).split())
+                    return int(kv["port"])
+        if proc.poll() is not None:
+            raise RuntimeError(f"subprocess exited early rc={proc.returncode}")
+        time.sleep(0.05)
     raise RuntimeError("subprocess did not announce its port in time")
 
 
@@ -81,16 +92,20 @@ def _terminate(proc: subprocess.Popen) -> None:
         proc.wait(timeout=2)
 
 
-def _dump_stderr(procs: dict[str, subprocess.Popen]) -> str:
+def _dump_logs(procs_logs: dict[str, tuple[subprocess.Popen, Path]]) -> str:
     parts = []
-    for name, p in procs.items():
-        stderr = ""
-        if p.stderr is not None:
-            try:
-                stderr = p.stderr.read() or ""
-            except Exception as exc:  # noqa: BLE001
-                stderr = f"<failed to read stderr: {exc!r}>"
-        parts.append(f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{stderr}\n")
+    for name, (p, log_path) in procs_logs.items():
+        try:
+            content = (
+                log_path.read_text(encoding="utf-8", errors="replace")
+                if log_path.exists()
+                else ""
+            )
+        except OSError as exc:
+            content = f"<failed to read {log_path}: {exc!r}>"
+        parts.append(
+            f"--- {name} (pid={p.pid}, rc={p.returncode}) ---\n{content}\n"
+        )
     return "\n".join(parts)
 
 
@@ -127,6 +142,8 @@ def test_implementer_full_flow_through_ui(tmp_path: Path) -> None:
     repo_dir = tmp_path / "bare-repo.git"
     experiment_id = "exp-impl-e2e"
     token = "impl-e2e-token"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
 
     repo, base_sha = _seed_bare_repo(repo_dir)
     # Push a child commit the operator will reference in the form.
@@ -144,6 +161,7 @@ def test_implementer_full_flow_through_ui(tmp_path: Path) -> None:
         committer_date=_E2E_DATE,
     )
 
+    server_log = logs_dir / "server.log"
     server = _spawn(
         [
             "eden_task_store_server",
@@ -161,11 +179,13 @@ def test_implementer_full_flow_through_ui(tmp_path: Path) -> None:
             token,
             "--subscribe-timeout",
             "1.0",
-        ]
+        ],
+        server_log,
     )
-    server_port = _read_port(server, _TASK_STORE_RE)
+    server_port = _read_port(server_log, server, _TASK_STORE_RE)
     task_store_url = f"http://127.0.0.1:{server_port}"
 
+    web_ui_log = logs_dir / "web-ui.log"
     web_ui = _spawn(
         [
             "eden_web_ui",
@@ -191,12 +211,16 @@ def test_implementer_full_flow_through_ui(tmp_path: Path) -> None:
             "0",
             "--claim-ttl-seconds",
             "60",
-        ]
+        ],
+        web_ui_log,
     )
-    web_port = _read_port(web_ui, _WEB_UI_RE)
+    web_port = _read_port(web_ui_log, web_ui, _WEB_UI_RE)
     web_url = f"http://127.0.0.1:{web_port}"
 
-    procs = {"task-store-server": server, "web-ui": web_ui}
+    procs_logs = {
+        "task-store-server": (server, server_log),
+        "web-ui": (web_ui, web_ui_log),
+    }
 
     try:
         # Seed proposal + implement task via wire client.
@@ -265,11 +289,11 @@ def test_implementer_full_flow_through_ui(tmp_path: Path) -> None:
             if resp.status_code != 200:
                 pytest.fail(
                     f"submit returned {resp.status_code}: {resp.text}\n"
-                    + _dump_stderr(procs)
+                    + _dump_logs(procs_logs)
                 )
             assert child_sha in resp.text
 
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)
 
         store = SqliteStore(
@@ -294,5 +318,5 @@ def test_implementer_full_flow_through_ui(tmp_path: Path) -> None:
         finally:
             store.close()
     finally:
-        for p in procs.values():
+        for p, _ in procs_logs.values():
             _terminate(p)


### PR DESCRIPTION
Audit follow-up to #41 (eden#39).

## Why

After fixing the orchestrator e2e tests, I audited the rest of the suite for the same pipe-buffer-back-pressure pattern. Four web-ui real-subprocess tests share the exact same `subprocess.PIPE`-without-drain shape:

- `test_implementer_e2e.py`
- `test_admin_e2e.py`
- `test_evaluator_e2e.py`
- `test_e2e_real_subprocess.py` (two tests)

They currently finish in 1.3-5.5 s, under the ~10 s pipe-fill threshold, so they don't flake today. But adding any new scenario, a slower CI runner, or extending an orchestrator-driven walkthrough would push them over and the failure shape would be the same `httpx.ReadTimeout` confusion that took multiple sessions to track down for eden#39.

This PR applies the same mechanical fix preventatively.

## What

Same shape as #41:

- `_spawn(args, log_path)` redirects stdout to a per-process file under `tmp_path/logs/`; merges stderr into stdout.
- `_read_port` / `_read_announcement` reads the file with a polling deadline (no blocking pipe reads).
- `_dump_logs` (renamed from `_dump_stderr`) reads from the file for failure diagnostics.
- `procs: dict[str, Popen]` becomes `procs_logs: dict[str, tuple[Popen, Path]]`.

## What this is NOT

I did **not** touch:

- `time.sleep(2.0)` in `test_e2e_real_subprocess.py:365` — deterministic wait past a 1 s `--claim-ttl-seconds` (CLI arg is `int` only). Could be compressed via an int→float CLI change but that's an API surface decision out of scope for a test-flakiness audit.
- `time.sleep(0.1)` and `time.sleep(0.2)` in conformance scenarios — thread-coordination barriers ensuring HTTP long-poll has reached the server before the main thread drives writes. The test still passes if it falls back to fast-path; no flake risk, just a weaker test of the long-poll specifically.
- `time.sleep(60)` in subprocess-runner tests — these are *the test's child command*, asserting that we kill long-runners. Sleep is the test, not a sync hack.
- `time.sleep(0.5)` in `test_container_exec_integration.py` — gated `pytest.mark.docker`, slow-by-design integration tests.

Each of these was deliberately ruled out with reasoning per the new "feedback_handoff_docs" memory rule (mark each item ranked-or-unordered + per-item evidence).

## Test plan

- [x] All 4 affected e2e tests pass after the fix.
- [x] 710 reference tests still pass + ruff + pyright clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)