### PR TITLE
Add EDEN_MAX_QUIESCENT_ITERATIONS env-var gate + .env.example rename leftovers

### DIFF
--- a/MANUAL_UI_ISSUES.md
+++ b/MANUAL_UI_ISSUES.md
@@ -57,20 +57,24 @@ when Phase 12 lands.
   signal for "this experiment is done"; that's a state transition, not a
   process exit, and other experiments keep running.
 
-**Workaround attempted in this worktree (and reverted).** The WIP commit
-on this branch bumped `--max-quiescent-iterations` to 36000 in
-`reference/compose/compose.yaml` (~10 hours at 1s poll) so manual-UI
-sessions wouldn't have the orchestrator quiesce-exit out from under
-them. That broke all four `compose-*` CI smoke jobs because their
-180s budget can't accommodate a 10-hour quiescence wait. Reverted
-to the original `30` (= 30s) value so smoke passes; the
-quiesce-exit-on-experiment-end design issue is still open and
-remains the substantive resolution direction above. A manual-UI
-operator who needs to keep the orchestrator alive past quiescence
-can override per-stack via `EDEN_MAX_QUIESCENT_ITERATIONS` (or by
-invoking the orchestrator service directly with a high value) —
-adding that env-var gate to compose.yaml is a small follow-up if
-the manual-UI workflow needs it routinely.
+**Escape hatch landed: `EDEN_MAX_QUIESCENT_ITERATIONS` env var.** The
+WIP commit on the manual-UI branch bumped `--max-quiescent-iterations`
+to 36000 directly in `reference/compose/compose.yaml`. That broke all
+four `compose-*` CI smoke jobs (their 180s budget can't accommodate a
+10h quiescence wait) and was reverted in PR #46. To unblock manual-UI
+sessions properly, `compose.yaml` now reads the value from the env:
+
+```yaml
+- --max-quiescent-iterations
+- "${EDEN_MAX_QUIESCENT_ITERATIONS:-30}"
+```
+
+`.env.example` ships the default `30` (smoke-friendly). Manual-UI
+operators bump this in `.env` (e.g., `36000` ≈ 10h) without touching
+compose.yaml or affecting CI. The substantive design discussion above
+(orchestrator-as-persistent-infra, deployment-supplied termination
+policy) remains open and is the long-term resolution; the env var is
+the operational escape hatch in the meantime.
 
 ---
 

--- a/reference/compose/.env.example
+++ b/reference/compose/.env.example
@@ -45,8 +45,15 @@ EDEN_SESSION_SECRET=eden-dev-session-secret-change-me
 EDEN_STORE_URL=postgresql://eden:eden-dev-password-change-me@postgres:5432/eden
 
 # --- Orchestrator policy ---
-EDEN_PLAN_TASKS=3
-EDEN_PROPOSALS_PER_PLAN=1
+EDEN_IDEATE_TASKS=3
+EDEN_IDEAS_PER_IDEATION=1
+# Iterations of zero progress before the orchestrator declares the
+# experiment done. Each iteration is one --poll-interval (1.0s by
+# default), so 30 = 30s of stall tolerance. Tuned low for the smoke
+# tests; manual-UI sessions where a human is drafting / claiming
+# at human speed should bump this (e.g., 36000 ≈ 10h). See
+# MANUAL_UI_ISSUES.md #1.
+EDEN_MAX_QUIESCENT_ITERATIONS=30
 
 # --- Subprocess / docker-exec mode (chunk 10d / 10d-followup-A) ---
 # Host paths bind-mounted into the worker hosts. setup-experiment
@@ -55,7 +62,6 @@ EDEN_PROPOSALS_PER_PLAN=1
 EDEN_EXPERIMENT_DIR_HOST=
 EDEN_GITEA_CREDS_DIR_HOST=
 # Docker-exec mode (compose.docker-exec.yaml) only:
-EDEN_EXEC_MODE=host
 EDEN_EXEC_IMAGE=eden-runtime:dev
 EDEN_DOCKER_GID=
 EDEN_CIDFILES_DIR_HOST=

--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -201,14 +201,15 @@ services:
       - ${EDEN_IDEATE_TASKS:-3}
       # Compose-friendly quiescence: 30 iterations × 1s = 30s of
       # zero progress before the orchestrator declares the
-      # experiment done. The default (3 × 0.1s = 0.3s) is tuned
-      # for the in-process e2e tests where workers start
-      # immediately; in Compose the worker hosts take longer to
-      # bind and start polling.
+      # experiment done. Tuned for the smoke tests where worker
+      # hosts auto-claim within milliseconds. Manual-UI sessions
+      # (a human at the keyboard) want a much higher value — set
+      # EDEN_MAX_QUIESCENT_ITERATIONS in .env to override. See
+      # MANUAL_UI_ISSUES.md #1 for the design discussion.
       - --poll-interval
       - "1.0"
       - --max-quiescent-iterations
-      - "30"
+      - "${EDEN_MAX_QUIESCENT_ITERATIONS:-30}"
       - --log-level
       - info
     volumes:


### PR DESCRIPTION
## Summary

- Replace the hardcoded `30` value for `--max-quiescent-iterations` in `reference/compose/compose.yaml` with `${EDEN_MAX_QUIESCENT_ITERATIONS:-30}`. Smoke keeps its 30-iteration default; manual-UI sessions override per-deployment via `.env`.
- Add `EDEN_MAX_QUIESCENT_ITERATIONS=30` to `.env.example` with a comment naming the trade-off.
- Resolves issue #1's operational escape hatch in `MANUAL_UI_ISSUES.md`. The substantive design discussion (orchestrator-as-persistent-infra, deployment-supplied termination policy) in `docs/design/orchestrator-and-worker-roles.md` remains open as Phase-12 work.

## Drive-by .env.example fixes

The directed-evolution rename pass (PR #45) updated `compose.yaml`'s env-var references but missed corresponding renames in `.env.example`:

- `EDEN_PLAN_TASKS` → `EDEN_IDEATE_TASKS`
- `EDEN_PROPOSALS_PER_PLAN` → `EDEN_IDEAS_PER_IDEATION`

Also drops `EDEN_EXEC_MODE` from `.env.example` (no compose service references it).

## Test plan

- [x] `bash reference/compose/healthcheck/smoke.sh` PASS (locally)
- [ ] CI's full check matrix passes