### PR TITLE
Web UI / orchestrator: fix issues #2, #6, #7 from manual-UI session

### DIFF
--- a/MANUAL_UI_ISSUES.md
+++ b/MANUAL_UI_ISSUES.md
@@ -78,7 +78,7 @@ the operational escape hatch in the meantime.
 
 ---
 
-## 2. Ideator draft form loses typed state if you navigate after a validation error
+## 2. ✅ Resolved (commit c30cafa). Ideator draft form loses typed state if you navigate after a validation error
 
 **What happened.** Filled in ideas on the ideator page, hit submit
 without parent_commits SHA → got a validation error. Couldn't recover by
@@ -105,6 +105,15 @@ validation) rather than always rendering an empty row.
   away" warning. A banner would help.
 - Consider rendering the draft state in `localStorage` so an accidental
   refresh doesn't lose work even before the first submit.
+
+**Resolved (commit c30cafa).** Added a `_DRAFT_BUFFERS: dict[(csrf,
+task_id), list[row]]` keyed identically to `_CLAIMS` (so the buffer
+naturally dies with the session). Written on every POST that carries
+idea rows: `add_row` (both no-JS and HTMX paths) and `submit_plan`
+(validation-error re-render). Read by `GET /ideator/<task>/draft`
+when present. Cleared on successful submit and on `status=error`
+submit. The two adjacent fixes (warning banner / `localStorage`)
+remain open as smaller follow-ups.
 
 ---
 
@@ -180,7 +189,7 @@ fetch-on-server, paste SHA).
 
 ---
 
-## 6. Orchestrator crashes the whole process on a malformed variant
+## 6. ✅ Resolved (commit 17d35d7). Orchestrator crashes the whole process on a malformed variant
 
 **What happened.** Built a CLI execute-submit that POSTed `create_variant`
 without setting the `branch` field. The first such variant reached
@@ -218,9 +227,24 @@ one variant's brokenness doesn't take down the whole dispatcher.
 (now fixed). But the orchestrator's blast radius for any *future*
 malformed variant state is what makes this a real issue.
 
+**Resolved (commit 17d35d7).** Picked the "log + skip" candidate.
+`_promote_successful_variants` in
+[`reference/packages/eden-dispatch/src/eden_dispatch/driver.py`](reference/packages/eden-dispatch/src/eden_dispatch/driver.py)
+now wraps each `integrate_variant(variant.variant_id)` in a broad
+`try/except` that logs and continues. The malformed variant stays in
+`status=success` without a `variant_commit_sha` (operator can
+investigate via the admin UI); healthy variants in the same iteration
+still promote. Quiescence accounting only counts true forward motion,
+so a logged-and-skipped exception does NOT mask itself by faking
+progress. Two regression tests added in
+[`reference/packages/eden-dispatch/tests/test_orchestrator_iteration.py`](reference/packages/eden-dispatch/tests/test_orchestrator_iteration.py).
+The two stronger candidates (server-side validity check at
+`create_variant`; surfacing as a recoverable variant state) remain
+open follow-ups.
+
 ---
 
-## 7. `_dispatch_evaluate` requires `variant.branch` indirectly via integration
+## 7. ✅ Resolved (commit 17d35d7, same root cause as #6). `_dispatch_evaluate` requires `variant.branch` indirectly via integration
 
 **What happened.** When the broken variant blocked integration, evaluate
 tasks for *other* variants were still dispatched correctly — confirmed by

--- a/reference/packages/eden-dispatch/src/eden_dispatch/driver.py
+++ b/reference/packages/eden-dispatch/src/eden_dispatch/driver.py
@@ -24,10 +24,13 @@ action.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from eden_contracts import EvaluateTask
 from eden_storage import Store
+
+_log = logging.getLogger(__name__)
 
 
 def run_orchestrator_iteration(
@@ -106,11 +109,34 @@ def _dispatch_evaluate_tasks(
 def _promote_successful_variants(
     store: Store, integrate_variant: Callable[[str], object]
 ) -> bool:
+    """Promote each ``success`` variant whose integration hasn't run yet.
+
+    Per-variant exceptions are caught, logged, and skipped so one
+    malformed variant cannot crash the orchestrator process. A variant
+    that raises (e.g. ``NotReadyForIntegration`` because ``branch`` is
+    missing) stays in ``status=success`` without a
+    ``variant_commit_sha`` — the operator can investigate it via the
+    admin UI without blocking promotion of healthy variants. Without
+    this guard a single bad variant + ``restart: on-failure`` produces
+    a tight crash loop that wedges the deployment.
+
+    Returns ``True`` if at least one variant was successfully
+    promoted; a per-variant exception does NOT count as progress, so
+    the orchestrator's quiescence accounting reflects only real
+    forward motion.
+    """
     progress = False
     for variant in store.list_variants(status="success"):
         if variant.variant_commit_sha is not None:
             continue
-        integrate_variant(variant.variant_id)
+        try:
+            integrate_variant(variant.variant_id)
+        except Exception:  # noqa: BLE001 — deliberately broad
+            _log.exception(
+                "integrate_variant raised for variant %s; skipping",
+                variant.variant_id,
+            )
+            continue
         progress = True
     return progress
 

--- a/reference/packages/eden-dispatch/tests/test_orchestrator_iteration.py
+++ b/reference/packages/eden-dispatch/tests/test_orchestrator_iteration.py
@@ -252,3 +252,125 @@ def test_quiesced_store_returns_false() -> None:
         evaluate_task_id_factory=_eval_factory,
     )
     assert progress is False
+
+
+def test_malformed_variant_does_not_crash_orchestrator(caplog) -> None:
+    """MANUAL_UI_ISSUES #6 / #7 — a malformed variant must not bring the orchestrator down.
+
+    Before the fix, a single ``success`` variant whose integration
+    callback raised (e.g. ``NotReadyForIntegration`` because
+    ``branch`` was missing on the variant record) would propagate up
+    through ``_promote_successful_variants`` →
+    ``run_orchestrator_iteration`` → the orchestrator's main loop and
+    crash the process. Combined with ``restart: on-failure``, this
+    produced a tight crash loop until an operator hand-patched the
+    bad variant.
+
+    The fix logs + skips per-variant exceptions. Healthy variants in
+    the same iteration must still promote.
+    """
+    import logging
+
+    store = _make_store()
+    bad_id = _drive_variant_to_success(store)
+    # Drive a second variant to success so we can confirm a healthy
+    # one in the same iteration still gets promoted.
+    now = _now_factory()
+    idea = Idea(
+        idea_id="p-good",
+        experiment_id=store.experiment_id,
+        slug="feat-good",
+        priority=1.0,
+        parent_commits=["a" * 40],
+        artifacts_uri="file:///tmp/artifacts",
+        state="drafting",
+        created_at=now(),
+    )
+    store.create_idea(idea)
+    store.mark_idea_ready("p-good")
+    store.create_execute_task("t-exec-good", "p-good")
+    claim = store.claim("t-exec-good", "executor-1")
+    good_variant = Variant(
+        variant_id="tr-good",
+        experiment_id=store.experiment_id,
+        idea_id="p-good",
+        status="starting",
+        parent_commits=["a" * 40],
+        branch="work/feat-good",
+        started_at=now(),
+    )
+    store.create_variant(good_variant)
+    store.submit(
+        "t-exec-good",
+        claim.token,
+        ExecuteSubmission(status="success", variant_id="tr-good", commit_sha="d" * 40),
+    )
+    store.accept("t-exec-good")
+    store.create_evaluate_task("t-eval-good", "tr-good")
+    eclaim = store.claim("t-eval-good", "evaluator-1")
+    store.submit(
+        "t-eval-good",
+        eclaim.token,
+        EvaluateSubmission(status="success", variant_id="tr-good", evaluation={"loss": 0.4}),
+    )
+    store.accept("t-eval-good")
+
+    promoted: list[str] = []
+
+    def integrate(variant_id: str) -> None:
+        if variant_id == bad_id:
+            raise RuntimeError(f"variant '{variant_id}' has no branch")
+        promoted.append(variant_id)
+        store.integrate_variant(variant_id, "c" * 40)
+
+    with caplog.at_level(logging.ERROR, logger="eden_dispatch.driver"):
+        # Must not raise.
+        progress = run_orchestrator_iteration(
+            store,
+            implement_task_id_factory=_impl_factory,
+            evaluate_task_id_factory=_eval_factory,
+            integrate_variant=integrate,
+        )
+
+    # The healthy variant promoted; progress reflects that.
+    assert progress is True
+    assert promoted == ["tr-good"]
+    assert store.read_variant("tr-good").variant_commit_sha == "c" * 40
+    # The bad variant is still success without an integration commit
+    # (operator can investigate via the admin UI).
+    bad = store.read_variant(bad_id)
+    assert bad.status == "success"
+    assert bad.variant_commit_sha is None
+    # The exception was logged.
+    assert any(
+        "integrate_variant raised" in r.message and bad_id in r.message
+        for r in caplog.records
+    )
+
+
+def test_only_malformed_variant_returns_false_progress(caplog) -> None:
+    """If the only success variant is malformed, the iteration reports no progress.
+
+    A logged-and-skipped exception MUST NOT count as a true forward
+    transition for quiescence accounting; otherwise a steady stream of
+    crashes-as-progress would mask the malformed variant from
+    operators relying on quiesce-exit timing.
+    """
+    import logging
+
+    store = _make_store()
+    bad_id = _drive_variant_to_success(store)
+
+    def integrate(variant_id: str) -> None:
+        raise RuntimeError(f"variant '{variant_id}' has no branch")
+
+    with caplog.at_level(logging.ERROR, logger="eden_dispatch.driver"):
+        progress = run_orchestrator_iteration(
+            store,
+            implement_task_id_factory=_impl_factory,
+            evaluate_task_id_factory=_eval_factory,
+            integrate_variant=integrate,
+        )
+
+    assert progress is False
+    assert store.read_variant(bad_id).variant_commit_sha is None

--- a/reference/services/web-ui/src/eden_web_ui/routes/ideator.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/ideator.py
@@ -47,6 +47,15 @@ router = APIRouter(prefix="/ideator")
 # recovers stranded tasks (eden_dispatch.sweep_expired_claims).
 _CLAIMS: dict[tuple[str, str], str] = {}
 
+# In-memory mapping of (csrf_token, task_id) -> draft form rows. Holds
+# the most-recently-typed idea rows so a navigation away from the
+# claim/submit page (back button, refresh, nav click) doesn't lose the
+# user's input. Same key shape as _CLAIMS so the buffer naturally dies
+# with the session; cleared on successful submit / status=error
+# submit. Written on every POST that carries idea rows
+# (add_row + submit, including validation-error re-render).
+_DRAFT_BUFFERS: dict[tuple[str, str], list[dict[str, str]]] = {}
+
 
 def _claim_key(session_csrf: str, task_id: str) -> tuple[str, str]:
     return (session_csrf, task_id)
@@ -123,6 +132,8 @@ async def draft_form(
             status_code=303,
         )
     config = request.app.state.experiment_config
+    buffered = _DRAFT_BUFFERS.get(_claim_key(session.csrf, task_id))
+    form_state = buffered if buffered else [_empty_row()]
     return request.app.state.templates.TemplateResponse(
         request,
         "ideator_claim.html",
@@ -132,8 +143,8 @@ async def draft_form(
             "objective": config.objective,
             "evaluation_schema": config.evaluation_schema.root,
             "errors": None,
-            "form_state": [_empty_row()],
-            "row_indices": [0],
+            "form_state": form_state,
+            "row_indices": list(range(len(form_state))),
         },
     )
 
@@ -167,6 +178,17 @@ async def add_row(task_id: str, request: Request):
             request, "/ideator/?banner=claim+missing+from+session"
         )
 
+    slugs = [str(v) for v in form.getlist("slug")]
+    priorities = [str(v) for v in form.getlist("priority")]
+    parents = [str(v) for v in form.getlist("parent_commits")]
+    rationales = [str(v) for v in form.getlist("rationale")]
+    typed_state = _form_state_from_inputs(slugs, priorities, parents, rationales)
+    # Persist typed input so a navigation away + return to GET /draft
+    # re-hydrates the form. Append the new empty row so the buffered
+    # row count matches what was just rendered.
+    state = typed_state + [_empty_row()]
+    _DRAFT_BUFFERS[_claim_key(session.csrf, task_id)] = state
+
     if is_htmx_request(request):
         # The htmx-enhanced path: figure out where the new row goes
         # by counting existing rows in the form, then render only
@@ -185,12 +207,6 @@ async def add_row(task_id: str, request: Request):
         )
 
     config = request.app.state.experiment_config
-    slugs = [str(v) for v in form.getlist("slug")]
-    priorities = [str(v) for v in form.getlist("priority")]
-    parents = [str(v) for v in form.getlist("parent_commits")]
-    rationales = [str(v) for v in form.getlist("rationale")]
-    state = _form_state_from_inputs(slugs, priorities, parents, rationales)
-    state.append(_empty_row())
     return request.app.state.templates.TemplateResponse(
         request,
         "ideator_claim.html",
@@ -234,6 +250,7 @@ async def submit_plan(task_id: str, request: Request) -> HTMLResponse | Redirect
         except DispatchError as exc:
             return _render_error(request, _wire_error_banner(exc))
         _CLAIMS.pop(_claim_key(session.csrf, task_id), None)
+        _DRAFT_BUFFERS.pop(_claim_key(session.csrf, task_id), None)
         return _render_submitted(request, task_id, status="error", idea_ids=())
 
     slugs = [str(v) for v in form.getlist("slug")]
@@ -242,6 +259,10 @@ async def submit_plan(task_id: str, request: Request) -> HTMLResponse | Redirect
     rationales = [str(v) for v in form.getlist("rationale")]
     drafts, errors = parse_idea_rows(slugs, priorities, parents, rationales)
     if errors:
+        form_state = _form_state_from_inputs(slugs, priorities, parents, rationales)
+        # Buffer typed state so a navigation away + return to GET
+        # /draft re-hydrates the form (issue #2 in MANUAL_UI_ISSUES).
+        _DRAFT_BUFFERS[_claim_key(session.csrf, task_id)] = form_state
         return request.app.state.templates.TemplateResponse(
             request,
             "ideator_claim.html",
@@ -251,7 +272,7 @@ async def submit_plan(task_id: str, request: Request) -> HTMLResponse | Redirect
                 "objective": config.objective,
                 "evaluation_schema": config.evaluation_schema.root,
                 "errors": errors,
-                "form_state": _form_state_from_inputs(slugs, priorities, parents, rationales),
+                "form_state": form_state,
                 "row_indices": list(range(max(1, len(slugs) or 1))),
             },
             status_code=400,
@@ -300,6 +321,7 @@ async def submit_plan(task_id: str, request: Request) -> HTMLResponse | Redirect
         return _render_orphaned(request, task_id, idea_ids, banner=banner)
 
     _CLAIMS.pop(_claim_key(session.csrf, task_id), None)
+    _DRAFT_BUFFERS.pop(_claim_key(session.csrf, task_id), None)
     return _render_submitted(
         request, task_id, status="success", idea_ids=tuple(idea_ids)
     )

--- a/reference/services/web-ui/tests/test_ideator_flow.py
+++ b/reference/services/web-ui/tests/test_ideator_flow.py
@@ -753,3 +753,123 @@ class TestStrandedClaim:
         )
         assert n == 1
         assert store.read_task("t-strand").state == "pending"
+
+
+class TestDraftBufferReHydration:
+    """MANUAL_UI_ISSUES #2 — typed draft input survives navigation.
+
+    Before the fix, a user who hit a validation error and then
+    navigated away (back / refresh / nav click) and returned to
+    GET /ideator/<task>/draft saw an empty form. The claim was
+    still active in ``_CLAIMS`` but the typed values were gone.
+    The fix buffers form_state on every POST that carries idea
+    rows; the GET handler re-hydrates from that buffer.
+    """
+
+    def test_validation_error_then_get_re_renders_typed_input(
+        self, signed_in_client: TestClient, store: InMemoryStore
+    ) -> None:
+        store.create_ideate_task("t-rehydrate")
+        token = get_csrf(signed_in_client)
+        signed_in_client.post(
+            "/ideator/t-rehydrate/claim",
+            data={"csrf_token": token},
+            follow_redirects=False,
+        )
+        # Submit something that fails validation (bad priority, bad SHA).
+        bad = signed_in_client.post(
+            "/ideator/t-rehydrate/submit",
+            data={
+                "csrf_token": token,
+                "status": "success",
+                "slug": "feat-keep-me",
+                "priority": "not-a-number",
+                "parent_commits": "not-a-sha",
+                "rationale": "## why\n\nrationale text",
+            },
+        )
+        assert bad.status_code == 400
+        # Sanity: the immediate re-render preserves input.
+        assert "feat-keep-me" in bad.text
+
+        # Simulate the user navigating away and coming back via GET.
+        resp = signed_in_client.get("/ideator/t-rehydrate/draft")
+        assert resp.status_code == 200
+        # Typed values must come back instead of an empty form.
+        assert "feat-keep-me" in resp.text
+        assert "not-a-number" in resp.text
+        assert "not-a-sha" in resp.text
+        assert "rationale text" in resp.text
+
+    def test_add_row_buffers_typed_state_for_subsequent_get(
+        self, signed_in_client: TestClient, store: InMemoryStore
+    ) -> None:
+        store.create_ideate_task("t-add-buf")
+        token = get_csrf(signed_in_client)
+        signed_in_client.post(
+            "/ideator/t-add-buf/claim",
+            data={"csrf_token": token},
+            follow_redirects=False,
+        )
+        # User typed one row, clicked "add row" (no-JS path).
+        resp = signed_in_client.post(
+            "/ideator/t-add-buf/add_row",
+            data={
+                "csrf_token": token,
+                "slug": "first-feature",
+                "priority": "2.0",
+                "parent_commits": "a" * 40,
+                "rationale": "first idea rationale",
+            },
+        )
+        assert resp.status_code == 200
+        # User then refreshes / navigates back to the draft URL.
+        get_resp = signed_in_client.get("/ideator/t-add-buf/draft")
+        assert get_resp.status_code == 200
+        assert "first-feature" in get_resp.text
+        assert "first idea rationale" in get_resp.text
+
+    def test_buffer_cleared_after_successful_submit(
+        self, signed_in_client: TestClient, store: InMemoryStore
+    ) -> None:
+        store.create_ideate_task("t-clear-buf")
+        token = get_csrf(signed_in_client)
+        signed_in_client.post(
+            "/ideator/t-clear-buf/claim",
+            data={"csrf_token": token},
+            follow_redirects=False,
+        )
+        # Trigger a buffer write via add_row so the buffer is non-empty.
+        signed_in_client.post(
+            "/ideator/t-clear-buf/add_row",
+            data={
+                "csrf_token": token,
+                "slug": "before-success",
+                "priority": "1.0",
+                "parent_commits": "a" * 40,
+                "rationale": "before success",
+            },
+        )
+        # Successful submit clears the buffer. The simplest probe: a
+        # fresh ideate task on the same session must NOT inherit the
+        # prior buffer's state when GET'd.
+        ok = signed_in_client.post(
+            "/ideator/t-clear-buf/submit",
+            data={
+                "csrf_token": token,
+                "status": "success",
+                "slug": "before-success",
+                "priority": "1.0",
+                "parent_commits": "a" * 40,
+                "rationale": "before success",
+            },
+        )
+        assert ok.status_code == 200
+        # Re-claim the same task_id is not allowed (terminal); but
+        # we can directly check the module-level buffer dict to
+        # confirm the per-(session,task) entry is gone.
+        from eden_web_ui.routes.ideator import _DRAFT_BUFFERS
+
+        # Find any entry whose task_id is t-clear-buf.
+        leftover = [k for k in _DRAFT_BUFFERS if k[1] == "t-clear-buf"]
+        assert leftover == []


### PR DESCRIPTION
## Summary

Three bugs from `MANUAL_UI_ISSUES.md`, each landed as its own commit:

- **#2 — Ideator draft form loses typed state on navigation after a validation error.** Add a session-scoped `_DRAFT_BUFFERS` dict keyed identically to `_CLAIMS`. Written on every POST that carries idea rows (no-JS `add_row`, HTMX `add_row`, validation-error re-render in `submit_plan`). Read by GET `/ideator/<task>/draft` when present. Cleared on successful submit / status=error submit. Naturally dies with the session.
- **#6 — Orchestrator process crashes on a malformed variant.** Wrap `integrate_variant(variant.variant_id)` in `_promote_successful_variants` with a broad `except` that logs and continues. The malformed variant stays in `status=success` without a `variant_commit_sha` (operator can investigate via the admin UI); healthy variants in the same iteration still promote; quiescence accounting only counts true forward motion.
- **#7 — same root cause as #6**, no separate fix needed; resolved by the same commit.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -q` — 722 passed, 75 skipped (Postgres + docker, environment-gated)
- [x] `bash reference/compose/healthcheck/smoke.sh` — PASS (orchestrator reaches quiescence; ≥3 `variant.integrated`, ≥9 `task.completed`, ≥3 `variant/*` refs on gitea)
- [x] New regression tests:
  - `TestDraftBufferReHydration` (3 tests) in `reference/services/web-ui/tests/test_ideator_flow.py` — covers validation-error → GET path, add_row buffering, and post-submit clearing.
  - `test_malformed_variant_does_not_crash_orchestrator` + `test_only_malformed_variant_returns_false_progress` in `reference/packages/eden-dispatch/tests/test_orchestrator_iteration.py` — assert no crash, healthy variant in same iteration still promotes, quiescence accounting unaffected by skipped exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)