### PR TITLE
Apply rename-discipline (PR #66/#67) to merged 12a plans

### DIFF
--- a/docs/plans/eden-phase-12a-1-worker-identity.md
+++ b/docs/plans/eden-phase-12a-1-worker-identity.md
@@ -1024,7 +1024,7 @@ step 2 and come back green around step 8.
   because it depends on the orchestrator-as-role contract.
 - **`intended_executor` hint on ideas** (12a-3). Per §D.4 there's
   no `intended_executor` field on ideas in 12a-1; it lands in
-  12a-3 alongside the operator-driven ideate-task creation flow.
+  12a-3 alongside the operator-driven ideation-task creation flow.
 - **Per-decision dispatch_mode flags** (12a-2). Tasks gain
   `target` here, but the orchestrator doesn't yet honor a
   per-decision-type opt-out for auto-dispatch.

--- a/docs/plans/eden-phase-12a-3-lifecycle-policy.md
+++ b/docs/plans/eden-phase-12a-3-lifecycle-policy.md
@@ -112,7 +112,7 @@ discipline" section apply unchanged. Specific check for this
 chunk: `termination` (noun/verb) and `terminated` (state) are the
 canonical forms; "abort" / "halt" / "stop" are NOT used as
 synonyms for the experiment-level transition (they may still
-appear in policy callable names like `abort_on_eval_error_rate`,
+appear in policy callable names like `abort_on_evaluation_error_rate`,
 where "abort" is the policy author's word, not a spec term).
 
 ## 2. Decisions


### PR DESCRIPTION
## Summary

Two legacy-vocabulary survivors in already-merged Phase 12 plans that PR #66's comprehensive rename-discipline cleanup didn't catch — the guardrail's allowlist (`docs/plans/eden-phase-*`) intentionally exempts plan files as historical artifacts, so legacy vocab inside them slipped through.

- **`docs/plans/eden-phase-12a-1-worker-identity.md` §11 (Out-of-scope):** "operator-driven ideate-task creation flow" → `ideation-task` (kebab verb-form retired by PR #66; canonical gerund-noun is `ideation`).
- **`docs/plans/eden-phase-12a-3-lifecycle-policy.md` §1 (Naming discipline):** policy-author example name `abort_on_eval_error_rate` → `abort_on_evaluation_error_rate` (`eval_error` retired in favor of `evaluation_error` per PR #67).

The intentional `rename-discipline:cite` occurrence in 12a-2 (citing `eval_error` as the retired form) is left untouched per the cite-marker convention.

## Why fix merged plans

The repo's established posture is "don't rewrite history" for merged plans (per the bulk-refactoring skill and AGENTS.md). These two hits are different from the historical-cite case the convention covers — they're non-cite uses of legacy vocab that read as if canonical. A future agent referring to these plans for context could copy the legacy form into new code; fixing them removes that risk without erasing any teaching content.

## Test plan

- [x] `markdownlint-cli2` clean on both files
- [x] `scripts/check-rename-discipline.py` clean
- [ ] CI markdownlint job passes
- [ ] CI rename-discipline job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)