### PR TITLE
Conformance: scenarios for §26 (work-branch uniqueness) + §27 (empty 2xx body)

### DIFF
--- a/conformance/scenarios/test_status_codes.py
+++ b/conformance/scenarios/test_status_codes.py
@@ -121,6 +121,40 @@ def test_replay_returns_200_with_cursor(wire_client: WireClient) -> None:
     assert isinstance(body.get("cursor"), int)
 
 
+def test_integrate_success_response_body_is_empty(wire_client: WireClient) -> None:
+    """spec/v0/07-wire-protocol.md §1.1 — empty 2xx responses MUST NOT carry a body.
+
+    The §5 integrate-variant endpoint is documented to respond
+    `200, empty body` on success and on same-value idempotent retries.
+    The transport-level §1.1 MUST forbids any payload on such empty
+    responses (a regression that emitted `null` or `{}` would
+    masquerade as a body and violate the rule). Asserts both that
+    the response carries zero bytes and — when the server advertises
+    a length — that `Content-Length: 0`.
+    """
+    variant_id = _seed.drive_to_success_variant(wire_client)
+    sha = "a" * 40
+    r = _seed.integrate_variant(wire_client, variant_id, variant_commit_sha=sha)
+    assert 200 <= r.status_code < 300, r.text
+    assert r.content == b"", (
+        f"spec/v0/07-wire-protocol.md §1.1 forbids body on empty 2xx "
+        f"responses; integrate /accept returned {r.content!r}"
+    )
+    cl = r.headers.get("content-length")
+    if cl is not None:
+        assert cl == "0", (
+            f"Content-Length must be 0 on empty 2xx; got {cl!r}"
+        )
+    # The §5 same-value idempotent retry MUST also return an empty
+    # body — the rule is on the response shape, not on the first call.
+    r2 = _seed.integrate_variant(wire_client, variant_id, variant_commit_sha=sha)
+    assert 200 <= r2.status_code < 300, r2.text
+    assert r2.content == b"", (
+        f"spec/v0/07-wire-protocol.md §1.1 forbids body on empty 2xx "
+        f"responses; integrate /accept idempotent retry returned {r2.content!r}"
+    )
+
+
 def test_reclaim_cause_vocabulary_closed(wire_client: WireClient) -> None:
     """spec/v0/07-wire-protocol.md §2.6 — invalid reclaim cause returns 400 bad-request.
 

--- a/conformance/scenarios/test_worker_branch_uniqueness.py
+++ b/conformance/scenarios/test_worker_branch_uniqueness.py
@@ -1,0 +1,73 @@
+"""Worker-branch uniqueness — chapter 03 §3.3."""
+
+from __future__ import annotations
+
+import pytest
+from conformance.harness import _seed
+from conformance.harness.wire_client import WireClient
+
+pytestmark = pytest.mark.conformance
+
+CONFORMANCE_GROUP = 'Executor submission'
+
+
+def test_colliding_variant_id_rejected_so_work_branches_remain_unique(
+    wire_client: WireClient,
+) -> None:
+    """spec/v0/03-roles.md §3.3 — two variants MUST NOT share a worker branch name.
+
+    Construction per MANUAL_UI §26: drive two execute submissions
+    against ideas that share a slug, with deliberately-equal
+    `variant_id` choices that — under any branch-naming scheme
+    derived from `<slug>-<variant_id>` — would produce the same
+    `refs/heads/work/<slug>-<variant_id>` ref. The first
+    `create_variant` MUST succeed; the second MUST be rejected
+    (the reference impl rejects via `eden://error/already-exists`
+    on the variant_id collision, which transitively prevents the
+    branch collision). The recorded variants observed via
+    list_variants MUST end up with no two entries sharing a `branch`
+    field — the §3.3 invariant on protocol-owned data.
+    """
+    pid_a = _seed.create_idea(wire_client, slug="collide")
+    pid_b = _seed.create_idea(wire_client, slug="collide")
+    shared_branch = "work/collide-shared-id-12345"
+    shared_variant_id = "tr-collision-12345"
+
+    v1 = _seed.create_variant(
+        wire_client,
+        idea_id=pid_a,
+        variant_id=shared_variant_id,
+        branch=shared_branch,
+        status="starting",
+    )
+    assert v1 == shared_variant_id
+
+    # Second create_variant with the same variant_id (and the same
+    # would-be branch) MUST be rejected. The reference impl raises
+    # AlreadyExists, surfacing as 409 eden://error/already-exists.
+    body = {
+        "variant_id": shared_variant_id,
+        "experiment_id": wire_client.experiment_id,
+        "idea_id": pid_b,
+        "status": "starting",
+        "parent_commits": ["0" * 40],
+        "branch": shared_branch,
+        "started_at": "2026-05-01T00:00:00Z",
+    }
+    r = wire_client.post(wire_client.variants_path(), json=body)
+    assert r.status_code == 409, r.text
+    assert r.json().get("type") == "eden://error/already-exists"
+
+    # End-state assertion on the §3.3 data invariant: no two variants
+    # in the store share a `branch`. The second create was rejected,
+    # so list_variants returns exactly one variant carrying
+    # `shared_branch`.
+    listed = wire_client.get(wire_client.variants_path())
+    listed.raise_for_status()
+    on_branch = [v for v in listed.json() if v.get("branch") == shared_branch]
+    assert len(on_branch) == 1, (
+        f"spec/v0/03-roles.md §3.3 forbids two variants sharing a worker "
+        f"branch name; observed {len(on_branch)} variants with "
+        f"branch={shared_branch!r}: {on_branch}"
+    )
+    assert on_branch[0]["variant_id"] == shared_variant_id

--- a/spec/v0/09-conformance.md
+++ b/spec/v0/09-conformance.md
@@ -52,7 +52,7 @@ The v1 scenario groups, with their primary spec citations:
 | Per-type event payloads | Each registered type's required fields. | [`05-event-protocol.md`](05-event-protocol.md) §3 |
 | Composite commits | Execution-task dispatch, execution-task terminal, evaluate-terminal cases, retry-exhausted `evaluation_error` terminalization, execution-task reclaim with in-flight variant. | [`04-task-protocol.md`](04-task-protocol.md) §4.3; [`05-event-protocol.md`](05-event-protocol.md) §2.2 |
 | Event delivery | Total order, replay from cursor 0, at-least-once via subscribe-reconnect, long-poll subscribe. | [`05-event-protocol.md`](05-event-protocol.md) §4; [`07-wire-protocol.md`](07-wire-protocol.md) §6.2 |
-| Status codes | Each operation's spec-pinned status, including the [`07-wire-protocol.md`](07-wire-protocol.md) §7 status mappings exercised through duplicate-create / bad-request paths and the [`05-event-protocol.md`](05-event-protocol.md) §4.4 replay binding. | [`05-event-protocol.md`](05-event-protocol.md) §4.4; [`07-wire-protocol.md`](07-wire-protocol.md) §2, §3, §4, §5, §6, §7 |
+| Status codes | Each operation's spec-pinned status, including the [`07-wire-protocol.md`](07-wire-protocol.md) §7 status mappings exercised through duplicate-create / bad-request paths, the [`05-event-protocol.md`](05-event-protocol.md) §4.4 replay binding, and the [`07-wire-protocol.md`](07-wire-protocol.md) §1.1 empty-body rule on 2xx responses without a payload. | [`05-event-protocol.md`](05-event-protocol.md) §4.4; [`07-wire-protocol.md`](07-wire-protocol.md) §1.1, §2, §3, §4, §5, §6, §7 |
 | Problem+json envelope | Shape + content-type. | [`07-wire-protocol.md`](07-wire-protocol.md) §7 |
 | Error vocabulary closure | Closed `eden://error/<name>` set; observed exhaustively. | [`07-wire-protocol.md`](07-wire-protocol.md) §7 |
 | Experiment-id header disagreement | 400 experiment-id-mismatch. | [`07-wire-protocol.md`](07-wire-protocol.md) §1.3 |
@@ -65,7 +65,7 @@ The v1+roles scenario groups (added in chunk 11c), with their primary spec citat
 | Group | Scope | Spec citations |
 |---|---|---|
 | Ideator submission | Drafting-idea precondition; status vocabulary; idea-set semantics. | [`03-roles.md`](03-roles.md) §2.4 |
-| Executor submission | Submission-shape preconditions; variant-binding; status vocabulary. | [`03-roles.md`](03-roles.md) §3.4 |
+| Executor submission | Submission-shape preconditions; variant-binding; status vocabulary; worker-branch uniqueness. | [`03-roles.md`](03-roles.md) §3.3, §3.4 |
 | Evaluator submission | Status vocabulary; evaluation-schema validation; per-status variant-side writes; evaluation_error non-grafting. | [`03-roles.md`](03-roles.md) §4.2, §4.4 |
 
 The v1+roles+integrator scenario groups (added in chunk 11d), with their primary spec citations:


### PR DESCRIPTION
## Summary

Adds two conformance scenarios for chapter-09-§5-named MUSTs that the suite was missing, both surfaced by MANUAL_UI_ISSUES.md §24's per-claim coverage pass.

- **§26 — Work-branch uniqueness** (`spec/v0/03-roles.md §3.3`): two `create_variant` requests against same-slug ideas with deliberately-equal `variant_id` choices — under any `<slug>-<variant_id>` branch-naming scheme — would produce a `refs/heads/work/<slug>-<variant_id>` collision. The reference impl's variant_id-uniqueness check rejects the second with 409 `eden://error/already-exists`, transitively preventing the branch collision. The end-state assertion on `list_variants` pins the §3.3 data invariant directly: exactly one variant carries the shared branch. Group: `Executor submission`.
- **§27 — Empty 2xx body** (`spec/v0/07-wire-protocol.md §1.1`): drives the §5 integrate-variant 200-empty-body endpoint and asserts the response body is zero bytes (and `Content-Length: 0` when advertised). Repeats on the same-value idempotent retry so the rule is asserted on both the first call and the idempotent path. A regression that emitted `null` or `{}` would fail. Group: `Status codes`.

Spec amendment: chapter 9 §5 index extended so each scenario's citation matches its declared `CONFORMANCE_GROUP` — `Executor submission` row gains §3.3, `Status codes` row gains §1.1. Without these the relevance-check leg of `check_citations.py` would reject the new tests.

Both scenarios pass the `check_citations.py` group-identity + MUST-citation + group-relevance triple. The reference impl is conformant on both (verified locally — 116/116 conformance scenarios pass).

## Test plan

- [x] `uv run pytest -q conformance/` — 116 passed
- [x] `uv run pytest -q` (full reference suite) — 722 passed, 75 skipped
- [x] `uv run python conformance/src/conformance/tools/check_citations.py` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run pyright` — 0 errors
- [x] `markdownlint-cli2` — 0 errors
- [x] `python3 scripts/spec-xref-check.py` — all 337 §-references resolve
- [x] `python3 scripts/check-rename-discipline.py` — clean
- [ ] CI conformance + lint jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)