### PR TITLE
Web-UI fix-its: #52 (commit SHA hints) + #53 (fetch before commit_exists) + #54 (gitea push instructions)

### DIFF
--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -341,6 +341,8 @@ services:
       - /etc/eden/credential-helper.sh
       - --clone-url
       - ${GITEA_CLONE_URL_HOST:-http://localhost:${GITEA_HOST_PORT:-3001}/eden/${EDEN_EXPERIMENT_ID:?}.git}
+      - --base-commit-sha
+      - ${EDEN_BASE_COMMIT_SHA:?EDEN_BASE_COMMIT_SHA must be set (run setup-experiment)}
       - --worker-id
       - web-ui-1
       - --host

--- a/reference/services/web-ui/src/eden_web_ui/app.py
+++ b/reference/services/web-ui/src/eden_web_ui/app.py
@@ -54,6 +54,7 @@ def make_app(
     now: Callable[[], datetime] | None = None,
     repo: GitRepo | None = None,
     clone_url: str | None = None,
+    base_commit_sha: str | None = None,
 ) -> FastAPI:
     """Construct the FastAPI app.
 
@@ -84,6 +85,7 @@ def make_app(
     app.state.templates = templates
     app.state.repo = repo
     app.state.clone_url = clone_url
+    app.state.base_commit_sha = base_commit_sha
 
     app.include_router(index_routes.router)
     app.include_router(auth_routes.router)

--- a/reference/services/web-ui/src/eden_web_ui/cli.py
+++ b/reference/services/web-ui/src/eden_web_ui/cli.py
@@ -118,6 +118,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "informational — affects only template rendering."
         ),
     )
+    parser.add_argument(
+        "--base-commit-sha",
+        default=None,
+        help=(
+            "Optional seed/base commit SHA written by setup-experiment "
+            "(EDEN_BASE_COMMIT_SHA). Surfaced on the ideator page as a "
+            "click-to-copy hint for the parent_commits field. Purely "
+            "informational — affects only template rendering."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -191,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
         secure_cookies=args.secure_cookies,
         repo=repo,
         clone_url=args.clone_url,
+        base_commit_sha=args.base_commit_sha,
     )
     uv_config = uvicorn.Config(
         app,

--- a/reference/services/web-ui/src/eden_web_ui/routes/ideator.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/ideator.py
@@ -71,6 +71,36 @@ def _list_recent_variants(store: Any, *, limit: int = 20) -> list[Any]:
     return items[-limit:]
 
 
+def _list_recent_integrated_variants(
+    store: Any, *, limit: int = 10
+) -> list[Any]:
+    """Return the most recent variants with a ``variant_commit_sha`` set.
+
+    Surfaces SHAs the operator can paste into the ideator form's
+    ``parent_commits`` field. Filters to ``status == "success"`` AND
+    ``variant_commit_sha is not None`` — i.e. variants the integrator
+    has produced a canonical squash commit for, per chapter 6 §3.4.
+    """
+    items = store.list_variants(status="success")
+    integrated = [v for v in items if v.variant_commit_sha is not None]
+    return integrated[-limit:]
+
+
+def _hint_context(request: Any, store: Any) -> dict[str, Any]:
+    """Shared parent_commits-hint context for ideator pages.
+
+    Returns ``{"base_commit_sha", "integrated_variants"}`` — the
+    seed/base SHA from the deployment env (CLI ``--base-commit-sha``)
+    and the most recent integrated variant SHAs. Both are intended
+    as click-to-copy hints for the ``parent_commits`` field. Either
+    may be empty/None in degenerate deployments.
+    """
+    return {
+        "base_commit_sha": getattr(request.app.state, "base_commit_sha", None),
+        "integrated_variants": _list_recent_integrated_variants(store),
+    }
+
+
 @router.get("/", response_class=HTMLResponse, response_model=None)
 async def list_pending(request: Request) -> HTMLResponse | RedirectResponse:
     session = get_session(request)
@@ -79,18 +109,20 @@ async def list_pending(request: Request) -> HTMLResponse | RedirectResponse:
     store = request.app.state.store
     pending = store.list_tasks(kind="ideation", state="pending")
     config = request.app.state.experiment_config
+    ctx: dict[str, Any] = {
+        "session": session,
+        "pending": pending,
+        "objective": config.objective,
+        "evaluation_schema": config.evaluation_schema.root,
+        "recent_ideas": _list_recent_ideas(store),
+        "recent_variants": _list_recent_variants(store),
+        "banner": request.query_params.get("banner"),
+    }
+    ctx.update(_hint_context(request, store))
     return request.app.state.templates.TemplateResponse(
         request,
         "ideator_list.html",
-        {
-            "session": session,
-            "pending": pending,
-            "objective": config.objective,
-            "evaluation_schema": config.evaluation_schema.root,
-            "recent_ideas": _list_recent_ideas(store),
-            "recent_variants": _list_recent_variants(store),
-            "banner": request.query_params.get("banner"),
-        },
+        ctx,
     )
 
 
@@ -134,18 +166,21 @@ async def draft_form(
     config = request.app.state.experiment_config
     buffered = _DRAFT_BUFFERS.get(_claim_key(session.csrf, task_id))
     form_state = buffered if buffered else [_empty_row()]
+    store = request.app.state.store
+    ctx: dict[str, Any] = {
+        "session": session,
+        "task_id": task_id,
+        "objective": config.objective,
+        "evaluation_schema": config.evaluation_schema.root,
+        "errors": None,
+        "form_state": form_state,
+        "row_indices": list(range(len(form_state))),
+    }
+    ctx.update(_hint_context(request, store))
     return request.app.state.templates.TemplateResponse(
         request,
         "ideator_claim.html",
-        {
-            "session": session,
-            "task_id": task_id,
-            "objective": config.objective,
-            "evaluation_schema": config.evaluation_schema.root,
-            "errors": None,
-            "form_state": form_state,
-            "row_indices": list(range(len(form_state))),
-        },
+        ctx,
     )
 
 
@@ -207,18 +242,21 @@ async def add_row(task_id: str, request: Request):
         )
 
     config = request.app.state.experiment_config
+    store = request.app.state.store
+    ctx: dict[str, Any] = {
+        "session": session,
+        "task_id": task_id,
+        "objective": config.objective,
+        "evaluation_schema": config.evaluation_schema.root,
+        "errors": None,
+        "form_state": state,
+        "row_indices": list(range(len(state))),
+    }
+    ctx.update(_hint_context(request, store))
     return request.app.state.templates.TemplateResponse(
         request,
         "ideator_claim.html",
-        {
-            "session": session,
-            "task_id": task_id,
-            "objective": config.objective,
-            "evaluation_schema": config.evaluation_schema.root,
-            "errors": None,
-            "form_state": state,
-            "row_indices": list(range(len(state))),
-        },
+        ctx,
     )
 
 
@@ -263,18 +301,20 @@ async def submit_idea(task_id: str, request: Request) -> HTMLResponse | Redirect
         # Buffer typed state so a navigation away + return to GET
         # /draft re-hydrates the form (issue #2 in MANUAL_UI_ISSUES).
         _DRAFT_BUFFERS[_claim_key(session.csrf, task_id)] = form_state
+        ctx: dict[str, Any] = {
+            "session": session,
+            "task_id": task_id,
+            "objective": config.objective,
+            "evaluation_schema": config.evaluation_schema.root,
+            "errors": errors,
+            "form_state": form_state,
+            "row_indices": list(range(max(1, len(slugs) or 1))),
+        }
+        ctx.update(_hint_context(request, store))
         return request.app.state.templates.TemplateResponse(
             request,
             "ideator_claim.html",
-            {
-                "session": session,
-                "task_id": task_id,
-                "objective": config.objective,
-                "evaluation_schema": config.evaluation_schema.root,
-                "errors": errors,
-                "form_state": form_state,
-                "row_indices": list(range(max(1, len(slugs) or 1))),
-            },
+            ctx,
             status_code=400,
         )
 

--- a/reference/services/web-ui/src/eden_web_ui/static/style.css
+++ b/reference/services/web-ui/src/eden_web_ui/static/style.css
@@ -109,3 +109,38 @@ button.danger { background: var(--error); }
 }
 .actions { display: flex; gap: 0.5rem; }
 .actions button { min-width: 10rem; }
+
+/* Issue #52: parent_commits hint panel + click-to-copy chip. */
+.parent-commits-hints {
+    margin: 1rem 0;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.02);
+}
+.parent-commits-hints h3 { margin-top: 0.75rem; font-size: 1em; }
+.parent-commits-hints table {
+    margin-top: 0.4rem;
+    font-size: 0.9em;
+    border-collapse: collapse;
+}
+.parent-commits-hints th,
+.parent-commits-hints td {
+    text-align: left;
+    padding: 0.2rem 0.6rem 0.2rem 0;
+}
+.hint-row-muted { color: #777; font-style: italic; }
+.copyable-sha {
+    cursor: pointer;
+    user-select: all;
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.06);
+    transition: background 0.15s;
+}
+.copyable-sha:hover,
+.copyable-sha:focus {
+    background: rgba(0, 0, 0, 0.12);
+    outline: none;
+}
+.copyable-sha.copied { background: #b9f1c1; }

--- a/reference/services/web-ui/src/eden_web_ui/templates/_parent_commits_hints.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/_parent_commits_hints.html
@@ -1,0 +1,70 @@
+{# Parent-commit SHA hints rendered above the ideator's draft form.
+   Issue #52: surface the seed/base SHA and recent integrated variant
+   SHAs so the operator has something to paste into the parent_commits
+   field. Click a SHA to copy it; pasting works without JS. #}
+<section class="parent-commits-hints" aria-label="parent commit hints">
+    <h2>parent commit hints</h2>
+    <p>Click a SHA to copy it. Paste into the
+        <code>parent commit SHAs</code> field below
+        (comma-separate multiple).</p>
+    {% if base_commit_sha %}
+    <p class="hint-row">
+        <strong>Base:</strong>
+        <code class="copyable-sha"
+              data-copy="{{ base_commit_sha }}"
+              tabindex="0"
+              role="button"
+              title="click to copy">{{ base_commit_sha }}</code>
+    </p>
+    {% else %}
+    <p class="hint-row hint-row-muted">
+        <strong>Base:</strong> not configured
+        (deployment did not pass <code>--base-commit-sha</code>).
+    </p>
+    {% endif %}
+    {% if integrated_variants %}
+    <h3>recent integrated variants</h3>
+    <table>
+        <thead>
+            <tr><th>variant</th><th>variant_commit_sha</th></tr>
+        </thead>
+        <tbody>
+            {% for v in integrated_variants %}
+            <tr>
+                <td><code>{{ v.variant_id }}</code></td>
+                <td>
+                    <code class="copyable-sha"
+                          data-copy="{{ v.variant_commit_sha }}"
+                          tabindex="0"
+                          role="button"
+                          title="click to copy">{{ v.variant_commit_sha }}</code>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p class="hint-row-muted">no integrated variants yet — only the base
+        SHA is available as a parent.</p>
+    {% endif %}
+</section>
+{# Vanilla click-to-copy: progressive enhancement. Without JS the SHA
+   is still selectable + copyable manually from the rendered <code>. #}
+<script>
+(function () {
+    document.querySelectorAll('.copyable-sha').forEach(function (el) {
+        function copy() {
+            var sha = el.getAttribute('data-copy') || el.textContent;
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(sha);
+            }
+            el.classList.add('copied');
+            setTimeout(function () { el.classList.remove('copied'); }, 800);
+        }
+        el.addEventListener('click', copy);
+        el.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); copy(); }
+        });
+    });
+})();
+</script>

--- a/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
@@ -58,11 +58,10 @@ git checkout {{ idea.parent_commits[0] }}</code></pre>
 git push origin my-work</code></pre></li>
         <li>Paste the resulting commit SHA below and submit. The UI fetches from origin on submit, then creates the canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit.</li>
         {% else %}
-        <li>Do your work in your own checkout, with parents matching <code>parent_commits</code> above.</li>
-        <li>Push your tip commit (any branch name works) to the bare repo at
-            {% if repo_path %}<code>{{ repo_path }}</code>{% else %}the configured bare repo{% endif %}.
-            The UI will create a canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit when you submit.</li>
-        <li>Paste the resulting commit SHA below and submit.</li>
+        <li><strong>Note:</strong> this deployment has no <code>--clone-url</code> configured, so the UI can't show a clone command. Ask your operator how to obtain pushable access to the central repo
+            {% if repo_path %}(the server's local clone path is <code>{{ repo_path }}</code>, but that is inside the web-ui process — not a URL you can push to from a workstation){% endif %}.</li>
+        <li>Once you have access, work on a checkout with parents matching <code>parent_commits</code> above, then push your tip commit to the central repo.</li>
+        <li>Paste the resulting commit SHA below and submit. The UI will fetch from origin, then create the canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit.</li>
         {% endif %}
     </ol>
 </section>

--- a/reference/services/web-ui/src/eden_web_ui/templates/ideator_claim.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/ideator_claim.html
@@ -13,6 +13,7 @@
     <h2>objective</h2>
     <p><strong>{{ objective.direction }}</strong> <code>{{ objective.expr }}</code></p>
 </section>
+{% include "_parent_commits_hints.html" %}
 <section class="evaluation-schema">
     <h2>evaluation schema (read-only)</h2>
     <table>

--- a/reference/services/web-ui/src/eden_web_ui/templates/ideator_list.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/ideator_list.html
@@ -7,6 +7,7 @@
     <h2>objective</h2>
     <p><strong>{{ objective.direction }}</strong> <code>{{ objective.expr }}</code></p>
 </section>
+{% include "_parent_commits_hints.html" %}
 <section class="evaluation-schema">
     <h2>evaluation schema</h2>
     <table>

--- a/reference/services/web-ui/tests/conftest.py
+++ b/reference/services/web-ui/tests/conftest.py
@@ -74,6 +74,39 @@ def client(app: FastAPI) -> Iterator[TestClient]:
         yield c
 
 
+BASE_SHA_FIXTURE = "a" * 40
+
+
+@pytest.fixture
+def app_with_base_sha(
+    store: InMemoryStore, artifacts_dir: Path
+) -> FastAPI:
+    """``app`` plus a ``base_commit_sha`` so the parent_commits hint
+    panel renders with a base SHA. Issue #52."""
+    return make_app(
+        store=store,
+        experiment_id=EXPERIMENT_ID,
+        experiment_config=_config(),
+        worker_id=WORKER_ID,
+        session_secret=SESSION_SECRET,
+        claim_ttl_seconds=3600,
+        artifacts_dir=artifacts_dir,
+        secure_cookies=False,
+        now=_now,
+        base_commit_sha=BASE_SHA_FIXTURE,
+    )
+
+
+@pytest.fixture
+def signed_in_client_with_base_sha(
+    app_with_base_sha: FastAPI,
+) -> Iterator[TestClient]:
+    with TestClient(app_with_base_sha) as c:
+        resp = c.post("/signin", follow_redirects=False)
+        assert resp.status_code == 303
+        yield c
+
+
 @pytest.fixture
 def signed_in_client(client: TestClient) -> TestClient:
     """A client that has POSTed /signin and holds a fresh session cookie."""
@@ -155,6 +188,29 @@ def exec_app(
     )
 
 
+GITEA_CLONE_URL_FIXTURE = "http://localhost:3001/eden/exp-web-ui.git"
+
+
+@pytest.fixture
+def exec_app_with_clone_url(
+    store: InMemoryStore, artifacts_dir: Path, bare_repo: GitRepo
+) -> FastAPI:
+    """``exec_app`` plus a ``clone_url`` so the gitea instructions render."""
+    return make_app(
+        store=store,
+        experiment_id=EXPERIMENT_ID,
+        experiment_config=_config(),
+        worker_id=WORKER_ID,
+        session_secret=SESSION_SECRET,
+        claim_ttl_seconds=3600,
+        artifacts_dir=artifacts_dir,
+        secure_cookies=False,
+        now=_now,
+        repo=bare_repo,
+        clone_url=GITEA_CLONE_URL_FIXTURE,
+    )
+
+
 @pytest.fixture
 def exec_client(exec_app: FastAPI) -> Iterator[TestClient]:
     with TestClient(exec_app) as c:
@@ -166,6 +222,16 @@ def signed_in_impl_client(exec_client: TestClient) -> TestClient:
     resp = exec_client.post("/signin", follow_redirects=False)
     assert resp.status_code == 303
     return exec_client
+
+
+@pytest.fixture
+def signed_in_impl_client_with_clone_url(
+    exec_app_with_clone_url: FastAPI,
+) -> Iterator[TestClient]:
+    with TestClient(exec_app_with_clone_url) as c:
+        resp = c.post("/signin", follow_redirects=False)
+        assert resp.status_code == 303
+        yield c
 
 
 def seed_implement_task(

--- a/reference/services/web-ui/tests/test_executor_flow.py
+++ b/reference/services/web-ui/tests/test_executor_flow.py
@@ -221,6 +221,114 @@ class TestErrorSubmission:
         assert variant.status == "error"
 
 
+class TestFetchBeforeCommitExists:
+    """Issue #53: ``submit`` must call ``repo.fetch_all_heads()`` before
+    ``repo.commit_exists(...)`` so a SHA the user just pushed to gitea
+    is visible in the web-ui's local clone.
+
+    Mirrors the integrator's per-integrate fetch (Phase 10d follow-up B).
+    """
+
+    def test_fetch_runs_before_commit_exists_on_success_submit(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Force the "origin is configured" arm regardless of the test
+        # repo's actual remote config.
+        monkeypatch.setattr(
+            executor_routes, "_repo_has_origin", lambda _repo: True
+        )
+
+        calls: list[str] = []
+        # Simulate "remote has the SHA but local clone hasn't fetched
+        # yet": commit_exists returns False until fetch_all_heads runs,
+        # then True. If submit calls commit_exists BEFORE fetch_all_heads,
+        # validation fails and the test fails loudly.
+        fetched = {"done": False}
+        real_commit_exists = bare_repo.commit_exists
+
+        def spy_fetch_all_heads() -> None:
+            calls.append("fetch_all_heads")
+            fetched["done"] = True
+
+        def spy_commit_exists(sha: str) -> bool:
+            calls.append("commit_exists")
+            if not fetched["done"]:
+                return False
+            return real_commit_exists(sha)
+
+        monkeypatch.setattr(bare_repo, "fetch_all_heads", spy_fetch_all_heads)
+        monkeypatch.setattr(bare_repo, "commit_exists", spy_commit_exists)
+        # Stub push_ref: the test fixture's bare repo has no real
+        # origin, but _repo_has_origin is forced True above, so the
+        # route would try to push.  No-op the push so the success path
+        # reaches the assertions.
+        monkeypatch.setattr(bare_repo, "push_ref", lambda _ref: None)
+
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="fetchy")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "fetchy-tip")
+
+        resp = _post_form(
+            signed_in_impl_client,
+            f"/executor/{task_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("commit_sha", child_sha),
+                ("description", ""),
+            ],
+        )
+        assert resp.status_code == 200, resp.text
+        # fetch_all_heads MUST appear before the first commit_exists call.
+        assert "fetch_all_heads" in calls, calls
+        first_fetch = calls.index("fetch_all_heads")
+        first_check = calls.index("commit_exists")
+        assert first_fetch < first_check, calls
+
+    def test_fetch_skipped_when_no_origin_configured(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # When the local clone has no origin remote (e.g. dev-only
+        # standalone deployment), skip the fetch — there is no remote
+        # to fetch from and an erroring fetch would be noise.
+        monkeypatch.setattr(
+            executor_routes, "_repo_has_origin", lambda _repo: False
+        )
+        called = {"fetch": False}
+
+        def spy_fetch_all_heads() -> None:
+            called["fetch"] = True
+
+        monkeypatch.setattr(bare_repo, "fetch_all_heads", spy_fetch_all_heads)
+
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="noorig")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "noorig-tip")
+
+        resp = _post_form(
+            signed_in_impl_client,
+            f"/executor/{task_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("commit_sha", child_sha),
+                ("description", ""),
+            ],
+        )
+        assert resp.status_code == 200, resp.text
+        assert called["fetch"] is False
+
+
 class TestPerSessionClaimIsolation:
     def test_second_session_cannot_draft_first_sessions_claim(
         self,

--- a/reference/services/web-ui/tests/test_executor_routes.py
+++ b/reference/services/web-ui/tests/test_executor_routes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from urllib.parse import urlencode
 
 from conftest import (
+    GITEA_CLONE_URL_FIXTURE,
     get_csrf,
     seed_implement_task,
 )
@@ -275,3 +276,79 @@ class TestRepoExposure:
         )
         resp = signed_in_impl_client.get(f"/executor/{task_id}/draft")
         assert str(bare_repo.path) in resp.text
+
+
+class TestCloneUrlInstructions:
+    """Issue #54: instructions must point at the gitea remote, not the
+    container-internal bare-repo path. When ``clone_url`` is configured
+    (the production / Compose path), the rendered instructions show the
+    clone URL and do NOT reference the in-container bare-repo path as
+    a push destination."""
+
+    def _claim(
+        self,
+        client: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+        slug: str = "demo",
+    ) -> str:
+        task_id, _ = seed_implement_task(store, base_sha=base_sha, slug=slug)
+        csrf = get_csrf(client)
+        resp = _post_form(
+            client,
+            f"/executor/{task_id}/claim",
+            [("csrf_token", csrf)],
+        )
+        assert resp.status_code == 303
+        return task_id
+
+    def test_clone_url_renders_clone_command(
+        self,
+        signed_in_impl_client_with_clone_url: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+    ) -> None:
+        task_id = self._claim(
+            signed_in_impl_client_with_clone_url, store, base_sha
+        )
+        resp = signed_in_impl_client_with_clone_url.get(
+            f"/executor/{task_id}/draft"
+        )
+        assert resp.status_code == 200
+        assert GITEA_CLONE_URL_FIXTURE in resp.text
+        assert "git clone" in resp.text
+        assert "git push origin" in resp.text
+
+    def test_clone_url_block_does_not_advertise_legacy_push_path(
+        self,
+        signed_in_impl_client_with_clone_url: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+    ) -> None:
+        task_id = self._claim(
+            signed_in_impl_client_with_clone_url, store, base_sha
+        )
+        resp = signed_in_impl_client_with_clone_url.get(
+            f"/executor/{task_id}/draft"
+        )
+        assert resp.status_code == 200
+        # The legacy instruction "Push your tip commit ... to the bare
+        # repo at <container path>" must not appear when clone_url is
+        # configured.  Issue #54.
+        assert "Push your tip commit" not in resp.text
+        assert "/var/lib/eden/repo" not in resp.text
+
+    def test_no_clone_url_warns_about_missing_clone_endpoint(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+    ) -> None:
+        task_id = self._claim(signed_in_impl_client, store, base_sha)
+        resp = signed_in_impl_client.get(f"/executor/{task_id}/draft")
+        assert resp.status_code == 200
+        # Fallback path: clearly tells the operator the deployment is
+        # incomplete rather than instructing the user to push to a
+        # local-fs path.
+        assert "no <code>--clone-url</code> configured" in resp.text
+        assert "not a URL you can push to from a workstation" in resp.text

--- a/reference/services/web-ui/tests/test_ideator_hints.py
+++ b/reference/services/web-ui/tests/test_ideator_hints.py
@@ -1,0 +1,167 @@
+"""Issue #52 — parent_commits SHA hints on the ideator page.
+
+The ideator landing AND draft pages must surface:
+
+- the seed/base commit SHA from ``--base-commit-sha``
+- the most recent integrated variants' ``variant_commit_sha``s
+  (status=success AND variant_commit_sha is not None)
+
+Both rendered as click-to-copy chips so the operator has something
+to paste into the ``parent_commits`` field.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from conftest import BASE_SHA_FIXTURE, get_csrf, seed_evaluate_task
+from eden_contracts import Variant
+from eden_storage import EvaluationSubmission, InMemoryStore
+from eden_web_ui.routes import ideator as ideator_routes
+from fastapi.testclient import TestClient
+
+
+def _post_form(client: TestClient, url: str, fields: list[tuple[str, str]]):
+    body = urlencode(fields)
+    return client.post(
+        url,
+        content=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        follow_redirects=False,
+    )
+
+
+def _seed_integrated_variant(
+    store: InMemoryStore,
+    *,
+    variant_id: str,
+    sha: str,
+    slug: str = "v",
+) -> None:
+    """Drive a variant through the full lifecycle and integrate it.
+
+    Mirrors what an end-to-end run produces: an executor-submitted
+    variant that the evaluator scores ``success`` and the integrator
+    stamps with ``variant_commit_sha`` per chapter 6 §3.4.
+    """
+    eval_task_id, _, _ = seed_evaluate_task(
+        store, slug=slug, variant_id=variant_id
+    )
+    eval_claim = store.claim(eval_task_id, "evaluator-w")
+    store.submit(
+        eval_task_id,
+        eval_claim.token,
+        EvaluationSubmission(
+            status="success",
+            variant_id=variant_id,
+            evaluation={"score": 0.5},
+        ),
+    )
+    store.accept(eval_task_id)
+    store.integrate_variant(variant_id, sha)
+
+
+class TestIdeatorListHints:
+    def test_base_sha_renders_when_configured(
+        self, signed_in_client_with_base_sha: TestClient
+    ) -> None:
+        resp = signed_in_client_with_base_sha.get("/ideator/")
+        assert resp.status_code == 200
+        assert "parent commit hints" in resp.text
+        assert BASE_SHA_FIXTURE in resp.text
+        assert 'class="copyable-sha"' in resp.text
+
+    def test_base_sha_warning_when_not_configured(
+        self, signed_in_client: TestClient
+    ) -> None:
+        resp = signed_in_client.get("/ideator/")
+        assert resp.status_code == 200
+        assert "not configured" in resp.text
+        # The warning surfaces the missing CLI flag.
+        assert "--base-commit-sha" in resp.text
+
+    def test_recent_integrated_variants_render(
+        self,
+        signed_in_client_with_base_sha: TestClient,
+        store: InMemoryStore,
+    ) -> None:
+        sha = "1" * 40
+        _seed_integrated_variant(store, variant_id="variant-int-1", sha=sha)
+        resp = signed_in_client_with_base_sha.get("/ideator/")
+        assert resp.status_code == 200
+        assert "recent integrated variants" in resp.text
+        assert "variant-int-1" in resp.text
+        assert sha in resp.text
+
+    def test_starting_variants_excluded_from_hints(
+        self,
+        signed_in_client_with_base_sha: TestClient,
+        store: InMemoryStore,
+    ) -> None:
+        # A variant in `starting` (no variant_commit_sha) must NOT appear
+        # in the hints panel — chapter 6 §3.4 wires variant_commit_sha
+        # only on integration. The variant may still appear in the
+        # broader "recent variants" panel below.
+        store.create_variant(
+            Variant(
+                variant_id="variant-pending",
+                experiment_id=store.experiment_id,
+                idea_id="idea-x",
+                status="starting",
+                parent_commits=["b" * 40],
+                branch="work/x-variant-pending",
+                started_at="2026-04-24T11:00:00Z",
+            )
+        )
+        resp = signed_in_client_with_base_sha.get("/ideator/")
+        # Slice to the hints panel.
+        text = resp.text
+        start = text.index('class="parent-commits-hints"')
+        end = text.index("</section>", start)
+        hints_block = text[start:end]
+        assert "variant-pending" not in hints_block
+
+
+class TestIdeatorDraftHints:
+    def test_draft_form_includes_hints_after_claim(
+        self,
+        signed_in_client_with_base_sha: TestClient,
+        store: InMemoryStore,
+    ) -> None:
+        sha = "9" * 40
+        _seed_integrated_variant(store, variant_id="variant-int-7", sha=sha)
+        store.create_ideation_task("t-hint")
+        csrf = get_csrf(signed_in_client_with_base_sha)
+        _post_form(
+            signed_in_client_with_base_sha,
+            "/ideator/t-hint/claim",
+            [("csrf_token", csrf)],
+        )
+        resp = signed_in_client_with_base_sha.get("/ideator/t-hint/draft")
+        assert resp.status_code == 200
+        assert BASE_SHA_FIXTURE in resp.text
+        assert sha in resp.text
+        assert "variant-int-7" in resp.text
+
+
+class TestHelpers:
+    def test_list_recent_integrated_variants_filters(
+        self, store: InMemoryStore
+    ) -> None:
+        # One integrated, one starting, one error.
+        _seed_integrated_variant(
+            store, variant_id="variant-ok", sha="d" * 40, slug="ok"
+        )
+        store.create_variant(
+            Variant(
+                variant_id="variant-pending",
+                experiment_id=store.experiment_id,
+                idea_id="idea-pending",
+                status="starting",
+                parent_commits=["b" * 40],
+                branch="work/pending-variant-pending",
+                started_at="2026-04-24T11:00:00Z",
+            )
+        )
+        out = ideator_routes._list_recent_integrated_variants(store)
+        assert [v.variant_id for v in out] == ["variant-ok"]


### PR DESCRIPTION
## Summary

Three web-UI fix-its from MANUAL_UI_ISSUES.md §3/§4/§5, batched into one PR (single web-ui surface).

- **#52** — Ideator landing + draft pages now render a `parent_commits` hint panel surfacing the seed/base commit SHA (new `--base-commit-sha` flag, fed by `EDEN_BASE_COMMIT_SHA` in Compose) plus the N most recent integrated variants' `variant_commit_sha`s. Each SHA is a click-to-copy chip (vanilla JS; selectable + manually-copyable as a no-JS fallback).
- **#53** — The fix itself (calling `repo.fetch_all_heads()` before `repo.commit_exists(...)` on `/executor/<id>/submit`) landed in PR #46; this PR adds an explicit unit test that pins the read-before-write contract — without it, a future refactor could silently regress to the original "remote has the SHA but local clone doesn't" behavior.
- **#54** — When `--clone-url` is set (the production / Compose path) the executor draft page already shows the gitea clone command. This PR adds a render test asserting that the gitea URL renders and the legacy in-container path `/var/lib/eden/repo` does NOT appear, and rewrites the `--clone-url`-absent fallback to warn that the deployment is incomplete rather than instructing the operator to push to a server-local filesystem path.

## Closes

- Closes #52
- Closes #53
- Closes #54

## Test plan

- [x] `uv run pytest -q reference/services/web-ui/tests/` (230 passed)
- [x] `uv run pytest -q` (733 passed, 75 skipped)
- [x] `uv run ruff check .` clean
- [x] `uv run pyright` clean
- [x] `npx markdownlint-cli2@0.14.0` clean
- [x] `python3 scripts/check-rename-discipline.py` clean
- [x] `bash reference/compose/healthcheck/e2e.sh` PASS locally
- [ ] CI lint/typecheck/pytest/e2e/conformance pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)