### PR TITLE
Phase 13c: Managed Postgres migration plan

### DIFF
--- a/docs/plans/eden-phase-13c-managed-postgres.md
+++ b/docs/plans/eden-phase-13c-managed-postgres.md
@@ -1,0 +1,2140 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     # Note: $EID is the chart's --experiment-id (per
+     # setup-experiment-helm.sh / chart values). The actual wire
+     # endpoints live at /v0/experiments/{experiment_id}/... — see
+     # reference/packages/eden-wire/src/eden_wire/server.py line 183
+     # for the base. The reclaim body is a POST JSON body
+     # ({"cause": "operator"}), not a query param.
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"cause": "operator"}' \
+         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Capture pre-snapshot baselines, then `pg_dump`.** Before
+   `pg_dump` runs, record the event count and the highest event
+   seq from the embedded Postgres. Step 4's SQL verification
+   and step 7's wire-endpoint verification both compare against
+   these baselines. The `task-store-server` is still running at
+   this point.
+
+   ```bash
+   # SQL-side baseline (queried directly against the embedded pod):
+   EVENT_COUNT_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
+     psql --user=eden --dbname=eden -tAc 'SELECT count(*) FROM event;')
+   MAX_SEQ_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
+     psql --user=eden --dbname=eden -tAc 'SELECT COALESCE(MAX(seq), 0) FROM event;')
+   echo "baseline: events=$EVENT_COUNT_BEFORE max_seq=$MAX_SEQ_BEFORE"
+
+   # Wire-side baseline (cursor walk; same shape as step 7's
+   # post-migration check). Captures the same count via the
+   # public surface so the post-migration verification can be
+   # apples-to-apples even if the operator can't shell into
+   # the new Postgres directly.
+   WIRE_COUNT_BEFORE=$(kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "$count"')
+   echo "wire-baseline events: $WIRE_COUNT_BEFORE"
+   ```
+
+   Save these three numbers. (Wire-side count and SQL-side
+   count SHOULD match for a quiesced experiment; if they
+   diverge, investigate before snapshotting — likely indicates
+   an in-flight write that the step-1 drain didn't catch.)
+
+   Then run `pg_dump`:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm against the baselines captured
+   in step 2:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects EVENT_COUNT_BEFORE
+   SELECT COALESCE(MAX(seq), 0) FROM event;
+   -- expects MAX_SEQ_BEFORE
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly. Endpoint shapes per
+   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+   lines 183-508 (and the `/healthz` endpoint added in 9e).
+   The `/v0/experiments/{E}/events` endpoint paginates via a
+   `cursor` query param (not `limit`); to confirm event-count
+   parity with the pre-snapshot state, walk the cursor or
+   simply count the response on a fresh deployment where it
+   fits in one page.
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # Walk the events cursor to count total events. Compare
+   # the result against the wire-side baseline captured in
+   # step 2 (the "wire-baseline events:" line).
+   # cursor=0 returns the first batch; the response includes a
+   # forward `cursor` to feed the next call.
+   #
+   # Both $TOKEN and $EID are operator-side env vars; pass them
+   # explicitly via `env` to the kubectl-exec'd shell so the
+   # double-quoted bash -c string sees the right values. (A
+   # single-quoted bash -c body would not expand $TOKEN at all;
+   # a double-quoted body with no `env` would expand $TOKEN on
+   # the operator side, which is what we want — but using `env`
+   # makes the boundary explicit.)
+   kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "events: $count"'
+   # Variants in success status (sanity-check a non-zero count
+   # for any non-trivial experiment). Operator-side $TOKEN and
+   # $EID expansion (no `env` passthrough needed — single curl
+   # call resolved by the outer shell):
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer ${TOKEN}" \
+       "http://localhost:8080/v0/experiments/${EID}/variants?status=success" \
+     | jq length
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+        # Capture the sibling container's IP on the kind network — kind's
+        # CoreDNS does NOT resolve sibling-container names by default
+        # (per §8.6), so the DSN must reference the IP directly. Stash
+        # the IP in $GITHUB_ENV so later steps see it.
+        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
+        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        # Use the sibling Postgres' IP (captured above), NOT
+        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
+        # for in-cluster Services; a host on the kind Docker network
+        # is reachable by IP but not by docker container name from
+        # inside pods. See §8.6.
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at the container's IP on that network
+(captured into `${EDEN_CI_PG_IP}` above). The kind cluster's
+CoreDNS does NOT resolve sibling-container names — see §8.6 —
+so the DSN MUST embed the IP, not `eden-ci-pg`. The IP-based
+path bypasses the kind-cluster Service abstraction and proves
+the external-DSN path works against a Postgres the chart did
+NOT create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/0-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/0-review.md
@@ -1,0 +1,17 @@
+**1. Missing Context**
+
+The problem is mostly well-defined, but two inherited constraints need to be stated explicitly before the plan is safe to execute.
+
+- The plan treats `postgres.external.connectionString` as “whatever psycopg/libpq accepts” in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:363), but the current server only dispatches `postgresql://` and `postgres://` URLs in [app.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/services/task-store-server/src/eden_task_store_server/app.py:21). A libpq keyword DSN would currently be misread as a SQLite path. The plan should either narrow the accepted format to URL DSNs only, or make a code change in scope.
+- The migration runbook assumes claims “expire” after scaling workers and the orchestrator down in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:894), but expiration is only operationalized by the orchestrator’s sweeper in [loop.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/services/orchestrator/src/eden_orchestrator/loop.py:67). The plan needs to explain who performs reclaim during drain, otherwise the “wait until no tasks are claimed” step is underspecified.
+
+**2. Feasibility**
+
+I have significant concerns here, so I would stop at this level and not evaluate alternatives/completeness/risk yet.
+
+- The embedded-mode DSN construction is not implementable as written. The plan says embedded mode builds `postgresql://eden:$(POSTGRES_PASSWORD)@...` in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:499) while also saying Helm will URI-encode the password with `urlquery` in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:530). Those two claims conflict, especially under 13a’s `secrets.existingSecret` model where Helm never sees the password value at all ([eden-phase-13a-helm-base-chart.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13a-helm-base-chart.md:456)). This needs a different design, not just better wording.
+- The migration runbook is not executable as written. Step 1 scales `ideator-host` as a StatefulSet in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:897), but 13a explicitly defined `ideator-host` as a Deployment in [eden-phase-13a-helm-base-chart.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13a-helm-base-chart.md:171). More importantly, scaling the orchestrator to zero before waiting for claimed tasks to clear conflicts with the sweeper dependency above, so the drain procedure can stall.
+
+**Overall Assessment**
+
+The plan has the right high-level target and most of the substrate concerns are identified, but it is not ready for implementation yet. I would resolve the store-URL contract, redesign the embedded-mode secret/DSN composition, and fix the migration drain/runbook mechanics first; after that, a second review round on alternatives/completeness would make sense.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/0.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/0.md
@@ -1,0 +1,1747 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq DSN. REQUIRED when mode=external (and no
+    # existingSecret). The DSN format is whatever psycopg/libpq
+    # accepts — postgresql://[user[:pass]@]host[:port][/dbname][?param=value...].
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Instead, it sources `EDEN_STORE_URL` via
+a new `eden.storeUrl` helper that returns:
+
+- For `embedded`: the chart-built URL pointing at
+  `<release>-eden-postgres:5432/eden` plus credentials from
+  the chart-managed Secret.
+- For `external`: either the operator-supplied
+  `connectionString` value rendered into the chart-managed
+  Secret, OR a `valueFrom: secretKeyRef:` pointing at
+  `existingSecret + connectionStringKey`.
+
+In BOTH modes, the rendered Pod spec uses
+`envFrom: secretRef:` (or `env: valueFrom: secretKeyRef:`) so
+the DSN is never visible in `kubectl get pod -o yaml`'s spec
+section — only in the Secret it references.
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": { "type": "string", "minLength": 1 }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN rendering helper
+
+The `eden.storeUrl` helper in `_helpers.tpl` returns a string
+suitable for `EDEN_STORE_URL`:
+
+```text
+{{- define "eden.storeUrl" -}}
+{{- if eq .Values.postgres.mode "embedded" -}}
+  {{- $host := printf "%s-eden-postgres" (include "eden.fullname" .) -}}
+  {{- /* DSN built from secrets.postgresPassword; emitted with
+         placeholder password that the runtime substitutes via
+         envFrom. The actual password comes from the Secret;
+         this helper just renders the host/port/db/user shape
+         and the optional sslmode/sslrootcert suffix. */ -}}
+  postgresql://eden:$(POSTGRES_PASSWORD)@{{ $host }}:5432/eden{{ include "eden.tlsSuffix" . }}
+{{- else if eq .Values.postgres.mode "external" -}}
+  {{- /* For external, the FULL DSN comes from the Secret; this
+         helper returns a sentinel that the Pod spec replaces via
+         envFrom. The TLS suffix is appended only if the operator
+         hasn't already encoded sslmode in their DSN; see §3.3.4. */ -}}
+  $(EDEN_STORE_URL_RAW){{ include "eden.tlsSuffix" . }}
+{{- end -}}
+{{- end -}}
+```
+
+The Pod spec uses two envs to compose the final URL safely:
+
+- `EDEN_STORE_URL_RAW`: from Secret (either chart-managed or
+  external).
+- `EDEN_STORE_URL`: command-line arg using shell-style
+  expansion to reference `$(EDEN_STORE_URL_RAW)` (Kubernetes
+  expands `$(VAR)` syntax in container args/env).
+
+This keeps the actual password out of the container's
+`spec.containers[0].args` and out of `kubectl get pod -o yaml`.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path needs the same posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. The `eden.storeUrl` helper for
+embedded mode uses `(urlquery .Values.secrets.postgresPassword)`
+when rendering the placeholder. For external mode, the operator
+supplies the DSN directly and is responsible for their own
+encoding (just like setup-experiment's CLI override path); the
+runbook flags this.
+
+The chart's `values.schema.json` does NOT validate that an
+external DSN parses as a libpq URL; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection error
+in the task-store-server's startup logs, which is tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Scale the orchestrator + worker hosts to
+   zero replicas:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-executor-host eden-evaluator-host \
+     eden-ideator-host --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for a final consistency check. Wait for in-flight
+   tasks to settle (claim TTLs expire); confirm via the wire
+   `/admin/tasks/` endpoint that no tasks are in
+   `state=claimed`.
+
+2. **Snapshot embedded Postgres via pg_dump.** Run from the
+   operator's workstation:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects same count as before
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly:
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # plus read_range to confirm event count matches:
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer $TOKEN" \
+       http://localhost:8080/v1/events/range
+   ```
+
+8. **Scale workers back up.**
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     eden-ideator-host --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL='postgresql://eden:ci-test-password@eden-ci-pg:5432/eden'
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at `eden-ci-pg:5432`. This bypasses
+the kind-cluster Service abstraction and proves the
+external-DSN path works against a Postgres the chart did NOT
+create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrl` (returns DSN per mode); add `eden.tlsSuffix` (renders sslmode + sslrootcert); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Switch DSN env from hard-coded embedded host to `eden.storeUrl` helper output. Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Add `EDEN_STORE_URL_RAW` from secret + compute final `EDEN_STORE_URL` via `$(EDEN_STORE_URL_RAW){{ include "eden.tlsSuffix" . }}`. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret only when `postgres.mode=embedded` OR (`postgres.mode=external` AND `postgres.external.existingSecret == ""`). Otherwise the operator's existingSecret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet + Service.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  task-store-server's `EDEN_STORE_URL_RAW` references chart-
+  managed Secret.
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  Secret is referenced via `valueFrom: secretKeyRef:`; chart-
+  managed Secret omits the `EDEN_STORE_URL` key.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret`: includes the volume mount;
+  `EDEN_STORE_URL` has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via grep on the rendered Pod spec).
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+The Pod spec composes `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` (from secret) and the TLS suffix.
+Kubernetes' `$(VAR)` expansion in env values requires
+`EDEN_STORE_URL_RAW` to be defined BEFORE `EDEN_STORE_URL` in
+the env list — the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+defines `$(VAR)` as expanded against the env vars defined
+earlier in the same `env:` list. The chart's template MUST
+order accordingly; ordering will be tested via a `helm
+template + grep` assertion.
+
+If `EDEN_STORE_URL_RAW` comes from `envFrom: secretRef:`, its
+position in the env-resolution order is implementation-
+defined. To avoid that risk, the chart uses explicit
+`env: - name: EDEN_STORE_URL_RAW; valueFrom: secretKeyRef: ...`
+(NOT `envFrom`) for this specific variable, even when other
+secrets come through `envFrom`. The other Secret keys
+(`EDEN_SHARED_TOKEN`, `EDEN_SESSION_SECRET`, etc.) keep using
+`envFrom`.
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1-review.md
@@ -1,0 +1,20 @@
+**1. Missing Context**
+
+This is materially better. The DSN-format limitation and the Secret-based composition story are now explicit. One context issue remains:
+
+- §3.2.2 still phrases embedded `secrets.existingSecret` as though `EDEN_STORE_URL` were already part of the inherited 13a contract, but §8.3b later says 13a did **not** include that key. Those sections should agree that this is a **new 13c requirement** for the embedded+`existingSecret` path, not an existing contract. ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:531), [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1624), [eden-phase-13a-helm-base-chart.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13a-helm-base-chart.md:456))
+
+**2. Feasibility**
+
+I still have a significant blocker here, so I would stop at this level again.
+
+- The migration drain/runbook still assumes TTL-based reclamation for worker-host claims, but the current worker hosts do not claim with `expires_at`. The orchestrator sweeper only reclaims claimed tasks that actually have an expiry ([sweep.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/packages/eden-dispatch/src/eden_dispatch/sweep.py:32)). The scripted workers claim without expiry ([workers.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/packages/eden-dispatch/src/eden_dispatch/workers.py:123), [workers.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/packages/eden-dispatch/src/eden_dispatch/workers.py:201)), and the subprocess hosts do too ([subprocess_mode.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/services/executor/src/eden_executor_host/subprocess_mode.py:164), [subprocess_mode.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/services/evaluator/src/eden_evaluator_host/subprocess_mode.py:149), [subprocess_mode.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/services/ideator/src/eden_ideator_host/subprocess_mode.py:307)). `claim_ttl_seconds` is a Web UI concept, not a general worker-host one ([cli.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/services/web-ui/src/eden_web_ui/cli.py:58)). So §3.8.2 / §8.3a’s “wait 2× claim_ttl_seconds and let the sweeper drain claims” is still not executable for claims held by executor/evaluator/ideator hosts. ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:965), [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1584))
+
+The plan needs one of these before it is implementable:
+
+- Make the drain procedure explicitly operator-driven for claimed host tasks (`admin reclaim` / API reclaim), and stop describing it as TTL-based.
+- Or add claim expiries to the worker-host claim paths as an in-scope code change, which would also invalidate the current “no code changes” framing.
+
+**Overall Assessment**
+
+This revision fixes the earlier DSN/TLS design issues. The remaining blocker is narrower but still material: the migration runbook’s drain strategy does not match how host claims actually work today. Once that is corrected, the plan looks close enough for a fuller pass on alternatives/completeness.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1.md
@@ -1,0 +1,1954 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST already contain `EDEN_STORE_URL`
+  (the existing 13a §3.3 production-secret contract — verified
+  by the chart's `existingSecret` documentation). The chart
+  does NOT compose anything; it just references the
+  operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters: claim-TTL expiration
+   is operationalized by the orchestrator's
+   `sweep_expired_claims` step in
+   [`reference/services/orchestrator/src/eden_orchestrator/loop.py`](../../reference/services/orchestrator/src/eden_orchestrator/loop.py)
+   line 67. If the orchestrator is scaled to zero before
+   in-flight claims expire, no sweeper runs and the
+   `state=claimed` tasks stay claimed forever. So the drain is
+   a two-phase scale-down:
+
+   First, scale the worker hosts (which are the only services
+   that can newly claim tasks) to zero. Per 13a Decision 3,
+   `executor-host` / `evaluator-host` / `web-ui` are
+   StatefulSets and `ideator-host` is a Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for in-flight tasks to settle. While this drain
+   proceeds, the orchestrator's running sweeper reclaims
+   stale claims as TTLs expire. Confirm via the wire
+   `/admin/tasks/` endpoint that no tasks remain in
+   `state=claimed`. Budget at least 2× the configured
+   `claim_ttl_seconds` for the wait. Then scale the
+   orchestrator to zero:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+   The web-ui (which can also do operator-driven reclaim per
+   the 9e admin module) MAY stay up during this window if
+   operators want to manually reclaim any stuck claim that
+   hasn't aged out within the budget. Scale it to zero after
+   the orchestrator if so.
+
+2. **Snapshot embedded Postgres via pg_dump.** Run from the
+   operator's workstation:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects same count as before
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly:
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # plus read_range to confirm event count matches:
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer $TOKEN" \
+       http://localhost:8080/v1/events/range
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL='postgresql://eden:ci-test-password@eden-ci-pg:5432/eden'
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at `eden-ci-pg:5432`. This bypasses
+the kind-cluster Service abstraction and proves the
+external-DSN path works against a Postgres the chart did NOT
+create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Sweeper / drain ordering in the migration runbook
+
+The `sweep_expired_claims` step that converts expired
+`claimed` tasks back to `pending` runs inside the
+orchestrator's loop iteration
+([`reference/services/orchestrator/src/eden_orchestrator/loop.py`](../../reference/services/orchestrator/src/eden_orchestrator/loop.py)
+line 67). If the migration runbook scaled the orchestrator
+to zero before workers' claims aged out, the claims would
+stay `claimed` indefinitely and the snapshot would capture
+"in-flight" state that the post-restore deployment cannot
+recover from cleanly (the tasks would be claim-stale on the
+new instance with no orchestrator history to know who held
+them).
+
+§3.8.2 step 1 mitigates this by phasing the scale-down:
+worker hosts to 0 first, wait while the still-running
+orchestrator sweeper drains claims, THEN orchestrator to 0.
+The wait budget is 2× `claim_ttl_seconds` to absorb the
+worst-case "claim made one tick before scale-down". The
+web-ui's admin-reclaim path is a manual escape hatch for any
+claim that hasn't aged out within budget.
+
+A future amendment MAY add an explicit "drain" CLI to the
+orchestrator that sets a "no new claims; finish in-flight
+work; quiesce" mode and exits cleanly, which would let the
+runbook collapse the two-phase scale-down. Out of scope for
+13c; the manual sequence is workable.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1.patch
@@ -1,0 +1,533 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/0.md	2026-05-08 12:11:52
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:19:27
+@@ -180,6 +180,7 @@
+   `postgres.external.connectionString`,
+   `postgres.external.existingSecret`,
+   `postgres.external.connectionStringKey`,
++  `postgres.external.tlsAlreadyEncodedInSecret`,
+   `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+   `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+ - Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+@@ -361,9 +362,17 @@
+     # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+ 
+   external:
+-    # The libpq DSN. REQUIRED when mode=external (and no
+-    # existingSecret). The DSN format is whatever psycopg/libpq
+-    # accepts — postgresql://[user[:pass]@]host[:port][/dbname][?param=value...].
++    # The libpq URL-form DSN. REQUIRED when mode=external (and no
++    # existingSecret). Format MUST be URL-style:
++    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
++    # (or `postgres://...`). Libpq's alternate keyword form
++    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
++    # accepted — the task-store-server dispatches store URLs by
++    # scheme prefix at
++    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
++    # lines 37-57; a keyword DSN would be misread as a SQLite
++    # bare-path. The values.schema.json regex enforces the
++    # url-form prefix (§3.2.1).
+     # NOTE: do NOT inline this in a public values.yaml; prefer
+     # existingSecret for production. The chart accepts inline only
+     # for ergonomic dev use. Prefer to URI-encode special chars in
+@@ -431,21 +440,26 @@
+ ```
+ 
+ The `task-store-server` Deployment template stops hard-coding
+-the embedded host name. Instead, it sources `EDEN_STORE_URL` via
+-a new `eden.storeUrl` helper that returns:
+-
+-- For `embedded`: the chart-built URL pointing at
+-  `<release>-eden-postgres:5432/eden` plus credentials from
+-  the chart-managed Secret.
+-- For `external`: either the operator-supplied
+-  `connectionString` value rendered into the chart-managed
+-  Secret, OR a `valueFrom: secretKeyRef:` pointing at
+-  `existingSecret + connectionStringKey`.
++the embedded host name. Per §3.2.2, the
++`EDEN_STORE_URL` env var sources from a Secret as a single
++pre-composed URL string in all four sub-cases (embedded with
++chart-managed secrets; embedded with `existingSecret`;
++external with `connectionString`; external with
++`existingSecret`). The new `_helpers.tpl` helpers
++`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
++to the right name/key per sub-case; the Pod spec wires those
++into a single `env: - name: EDEN_STORE_URL; valueFrom:
++secretKeyRef: {name: ..., key: ...}` entry.
+ 
+-In BOTH modes, the rendered Pod spec uses
+-`envFrom: secretRef:` (or `env: valueFrom: secretKeyRef:`) so
+-the DSN is never visible in `kubectl get pod -o yaml`'s spec
+-section — only in the Secret it references.
++In all sub-cases, the rendered Pod spec uses `valueFrom:
++secretKeyRef:` so the DSN is never visible in `kubectl get pod
++-o yaml`'s spec section — only in the Secret it references.
++The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
++keep using `envFrom: secretRef:` from 13a; only
++`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
++ordering note: with `valueFrom` we control resolution order
++explicitly, and we don't need `$(VAR)`-expansion across env
++entries).
+ 
+ ### 3.2 DSN handling and `values.schema.json` enforcement
+ 
+@@ -462,7 +476,11 @@
+             "anyOf": [
+               {
+                 "properties": {
+-                  "connectionString": { "type": "string", "minLength": 1 }
++                  "connectionString": {
++                    "type": "string",
++                    "minLength": 1,
++                    "pattern": "^postgres(ql)?://"
++                  }
+                 },
+                 "required": ["connectionString"]
+               },
+@@ -491,60 +509,99 @@
+ set fails with a clear error — per the AGENTS.md
+ substrate-plan pitfall on operator-required values.
+ 
+-#### 3.2.2 DSN rendering helper
++#### 3.2.2 DSN composition — Secret holds the full URL
+ 
+-The `eden.storeUrl` helper in `_helpers.tpl` returns a string
+-suitable for `EDEN_STORE_URL`:
++Both modes converge on the same Pod-spec shape: the
++`task-store-server`'s `EDEN_STORE_URL` env var sources from a
++Kubernetes Secret as a SINGLE pre-composed URL string. The
++chart never composes the DSN at template time from separate
++host/user/password fields — that posture would break under
++`secrets.existingSecret` (13a §3.3) where Helm doesn't see
++the password value at template time and therefore couldn't
++URI-encode it. Instead:
+ 
+-```text
+-{{- define "eden.storeUrl" -}}
+-{{- if eq .Values.postgres.mode "embedded" -}}
+-  {{- $host := printf "%s-eden-postgres" (include "eden.fullname" .) -}}
+-  {{- /* DSN built from secrets.postgresPassword; emitted with
+-         placeholder password that the runtime substitutes via
+-         envFrom. The actual password comes from the Secret;
+-         this helper just renders the host/port/db/user shape
+-         and the optional sslmode/sslrootcert suffix. */ -}}
+-  postgresql://eden:$(POSTGRES_PASSWORD)@{{ $host }}:5432/eden{{ include "eden.tlsSuffix" . }}
+-{{- else if eq .Values.postgres.mode "external" -}}
+-  {{- /* For external, the FULL DSN comes from the Secret; this
+-         helper returns a sentinel that the Pod spec replaces via
+-         envFrom. The TLS suffix is appended only if the operator
+-         hasn't already encoded sslmode in their DSN; see §3.3.4. */ -}}
+-  $(EDEN_STORE_URL_RAW){{ include "eden.tlsSuffix" . }}
+-{{- end -}}
+-{{- end -}}
+-```
+-
+-The Pod spec uses two envs to compose the final URL safely:
+-
+-- `EDEN_STORE_URL_RAW`: from Secret (either chart-managed or
+-  external).
+-- `EDEN_STORE_URL`: command-line arg using shell-style
+-  expansion to reference `$(EDEN_STORE_URL_RAW)` (Kubernetes
+-  expands `$(VAR)` syntax in container args/env).
++- **Embedded mode, chart-managed secrets.** The chart's
++  `secret.yaml` template URL-composes the DSN at template
++  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
++  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
++  and writes the result into the chart-managed Secret as the
++  `EDEN_STORE_URL` key. `urlquery` runs against the literal
++  password value the chart owns. The TLS suffix (if any) is
++  appended in the same `printf` call.
++- **Embedded mode, `secrets.existingSecret`.** The operator's
++  pre-created Secret MUST already contain `EDEN_STORE_URL`
++  (the existing 13a §3.3 production-secret contract — verified
++  by the chart's `existingSecret` documentation). The chart
++  does NOT compose anything; it just references the
++  operator-supplied key.
++- **External mode, `external.connectionString`.** The chart's
++  `secret.yaml` writes the operator-supplied DSN into the
++  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
++  no `urlquery` (the operator owns their password's encoding;
++  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
++  helper is appended at write time using the same
++  `?`-or-`&` discrimination logic.
++- **External mode, `external.existingSecret`.** The chart
++  references the operator-supplied Secret directly. The TLS
++  suffix CANNOT be appended at chart-template time (the chart
++  doesn't see the value). When `tls.enabled=true` AND
++  `external.existingSecret` is set, the operator MUST encode
++  the sslmode/sslrootcert in their pre-supplied DSN; the
++  chart's `values.schema.json` enforces that
++  `tls.enabled=false` is the only legal combination with
++  `external.existingSecret` UNLESS the operator confirms via
++  a separate value `external.tlsAlreadyEncodedInSecret: true`
++  (acknowledgement-style flag — sets a discriminator the
++  schema can require). This avoids silent mis-match where the
++  chart appends `?sslmode=...` after the operator already
++  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+ 
+-This keeps the actual password out of the container's
+-`spec.containers[0].args` and out of `kubectl get pod -o yaml`.
++In all four cases, the rendered Pod's env block contains a
++single `EDEN_STORE_URL` entry sourced via
++`valueFrom: secretKeyRef:` (chart-managed or
++operator-supplied Secret per the case). `EDEN_STORE_URL` is
++then passed through to the `task-store-server` `--store-url`
++flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
++expands the `$(VAR)` syntax in args; the secret value never
++appears in `spec.containers[0].args` literal text or in
++`kubectl get pod -o yaml`. (The
++[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
++specify that `$(VAR)` in `args` resolves against env vars
++defined for the container.)
+ 
++The `eden.storeUrl` helper, then, is NOT a runtime DSN
++composer — it's a template-time helper that picks the right
++SecretKeyRef (chart-managed name vs `existingSecret`) for the
++Pod spec to reference.
++
+ #### 3.2.3 Password URI-encoding
+ 
+ The compose `setup-experiment.sh` URI-encodes the password into
+ the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+-line 292). The chart's embedded path needs the same posture
++line 292). The chart's embedded path mirrors that posture
+ because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+-`#` reserved characters. The `eden.storeUrl` helper for
+-embedded mode uses `(urlquery .Values.secrets.postgresPassword)`
+-when rendering the placeholder. For external mode, the operator
+-supplies the DSN directly and is responsible for their own
+-encoding (just like setup-experiment's CLI override path); the
+-runbook flags this.
++`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
++template runs `urlquery .Values.secrets.postgresPassword` at
++template time, before composing the embedded DSN. This applies
++ONLY to the embedded-mode + chart-managed-secrets case (where
++Helm sees the password value); for `secrets.existingSecret`
++the operator pre-encoded the value when they wrote the secret
++key.
+ 
+-The chart's `values.schema.json` does NOT validate that an
+-external DSN parses as a libpq URL; that's psycopg's job at
+-connection time. A malformed DSN surfaces as a connection error
+-in the task-store-server's startup logs, which is tolerable.
++For external mode, the operator supplies the DSN directly
++(either inline in `connectionString` or pre-baked in
++`existingSecret`) and is responsible for their own password
++encoding — just like setup-experiment's CLI-password override
++path at line 292. The runbook + values comment flag this
++explicitly.
+ 
++The chart's `values.schema.json` partially validates external
++DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
++does NOT fully parse the DSN; that's psycopg's job at
++connection time. A malformed DSN surfaces as a connection
++error in the task-store-server's startup logs, which is
++tolerable.
++
+ ### 3.3 TLS posture
+ 
+ #### 3.3.1 The `postgres.tls` block
+@@ -569,6 +626,20 @@
+   weaker modes).
+ - When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+   verify-full}`, `tls.caBundleSecret` MUST be non-empty.
++- When `tls.enabled=true` AND `postgres.mode=external` AND
++  `postgres.external.existingSecret` is set, the operator
++  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
++  true` to acknowledge that the chart cannot append the
++  sslmode/sslrootcert query suffix to a Secret it doesn't
++  read at template time (per §3.2.2). Otherwise the chart
++  would silently mis-match — appending `?sslmode=verify-full`
++  to a DSN whose operator already encoded a different mode.
++  When the flag is set, the chart skips its `eden.tlsSuffix`
++  injection and the operator's pre-baked DSN is the
++  authoritative source. The chart STILL mounts the CA bundle
++  Secret at the documented path so the operator's DSN can
++  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
++  if they choose.
+ 
+ #### 3.3.2 CA bundle mounting
+ 
+@@ -891,20 +962,49 @@
+ between the operator's workstation and BOTH endpoints. The
+ runbook step-by-step:
+ 
+-1. **Drain workers.** Scale the orchestrator + worker hosts to
+-   zero replicas:
++1. **Drain workers.** Sequencing matters: claim-TTL expiration
++   is operationalized by the orchestrator's
++   `sweep_expired_claims` step in
++   [`reference/services/orchestrator/src/eden_orchestrator/loop.py`](../../reference/services/orchestrator/src/eden_orchestrator/loop.py)
++   line 67. If the orchestrator is scaled to zero before
++   in-flight claims expire, no sweeper runs and the
++   `state=claimed` tasks stay claimed forever. So the drain is
++   a two-phase scale-down:
+ 
++   First, scale the worker hosts (which are the only services
++   that can newly claim tasks) to zero. Per 13a Decision 3,
++   `executor-host` / `evaluator-host` / `web-ui` are
++   StatefulSets and `ideator-host` is a Deployment:
++
+    ```bash
+    kubectl scale statefulset -n eden-prod \
+-     eden-orchestrator eden-executor-host eden-evaluator-host \
+-     eden-ideator-host --replicas=0
++     eden-executor-host eden-evaluator-host \
++     --replicas=0
++   kubectl scale deployment -n eden-prod \
++     eden-ideator-host \
++     --replicas=0
+    ```
+ 
++   Wait for in-flight tasks to settle. While this drain
++   proceeds, the orchestrator's running sweeper reclaims
++   stale claims as TTLs expire. Confirm via the wire
++   `/admin/tasks/` endpoint that no tasks remain in
++   `state=claimed`. Budget at least 2× the configured
++   `claim_ttl_seconds` for the wait. Then scale the
++   orchestrator to zero:
++
++   ```bash
++   kubectl scale statefulset -n eden-prod \
++     eden-orchestrator --replicas=0
++   ```
++
+    The `task-store-server` keeps running so we can read its
+-   state for a final consistency check. Wait for in-flight
+-   tasks to settle (claim TTLs expire); confirm via the wire
+-   `/admin/tasks/` endpoint that no tasks are in
+-   `state=claimed`.
++   state for the final consistency check before snapshotting.
++   The web-ui (which can also do operator-driven reclaim per
++   the 9e admin module) MAY stay up during this window if
++   operators want to manually reclaim any stuck claim that
++   hasn't aged out within the budget. Scale it to zero after
++   the orchestrator if so.
+ 
+ 2. **Snapshot embedded Postgres via pg_dump.** Run from the
+    operator's workstation:
+@@ -981,14 +1081,21 @@
+        http://localhost:8080/v1/events/range
+    ```
+ 
+-8. **Scale workers back up.**
++8. **Scale workers back up.** Reverse-order from step 1: bring
++   the orchestrator up first so its sweeper is running before
++   workers start claiming, then bring the workers back. The
++   ideator-host is a Deployment per 13a Decision 3; the rest
++   are StatefulSets:
+ 
+    ```bash
+    kubectl scale statefulset -n eden-prod \
+      eden-orchestrator --replicas=2
+    kubectl scale statefulset -n eden-prod \
+      eden-executor-host eden-evaluator-host \
+-     eden-ideator-host --replicas=1
++     --replicas=1
++   kubectl scale deployment -n eden-prod \
++     eden-ideator-host \
++     --replicas=1
+    ```
+ 
+    Workers re-acquire leases on the live experiment(s) within
+@@ -1263,13 +1370,13 @@
+ 
+ | File | Change |
+ |---|---|
+-| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture. |
+-| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}. |
+-| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrl` (returns DSN per mode); add `eden.tlsSuffix` (renders sslmode + sslrootcert); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
++| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
++| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
++| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+ | `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+ | `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+-| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Switch DSN env from hard-coded embedded host to `eden.storeUrl` helper output. Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Add `EDEN_STORE_URL_RAW` from secret + compute final `EDEN_STORE_URL` via `$(EDEN_STORE_URL_RAW){{ include "eden.tlsSuffix" . }}`. |
+-| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret only when `postgres.mode=embedded` OR (`postgres.mode=external` AND `postgres.external.existingSecret == ""`). Otherwise the operator's existingSecret is the source. |
++| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
++| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+ | `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+ | `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+ | `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+@@ -1300,22 +1407,38 @@
+ 
+ `helm template` with each combination:
+ 
+-- `mode=embedded` (default): renders the StatefulSet + Service.
+-- `mode=external` + `connectionString`: omits StatefulSet;
+-  task-store-server's `EDEN_STORE_URL_RAW` references chart-
+-  managed Secret.
++- `mode=embedded` (default): renders the StatefulSet +
++  Service; the chart-managed Secret has an `EDEN_STORE_URL`
++  key whose value is the URL-composed DSN with the
++  `urlquery`-encoded password; the task-store-server Pod's
++  `EDEN_STORE_URL` env sources this key.
++- `mode=external` + `connectionString`: omits StatefulSet;
++  the chart-managed Secret has an `EDEN_STORE_URL` key whose
++  value is the operator-supplied DSN (with the TLS suffix
++  appended at template time when `tls.enabled=true`).
+ - `mode=external` + `existingSecret`: omits StatefulSet;
+-  Secret is referenced via `valueFrom: secretKeyRef:`; chart-
+-  managed Secret omits the `EDEN_STORE_URL` key.
++  the chart-managed Secret omits the `EDEN_STORE_URL` key;
++  the Pod's env sources from
++  `<external.existingSecret>/<external.connectionStringKey>`.
+ - `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+-  with `caBundleSecret`: includes the volume mount;
+-  `EDEN_STORE_URL` has
++  with `caBundleSecret` and inline `connectionString`:
++  includes the CA-bundle volume mount; the chart-managed
++  Secret's `EDEN_STORE_URL` value has
+   `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+-  appended (verified via grep on the rendered Pod spec).
++  appended (verified via decoded-Secret grep, since the
++  literal value is base64'd in the rendered Secret YAML).
++- `mode=external` + `tls.enabled=true` + `existingSecret`
++  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
++  lint time per §3.3.1.
+ - `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+   AND `tls.mode=verify-ca`: install fails at lint time.
+ - `mode=external` + neither `connectionString` nor
+   `existingSecret`: install fails at lint time.
++- `mode=external` + `connectionString=foo`: install fails at
++  lint time (URL-prefix regex rejects).
++- `mode=external` + libpq keyword DSN
++  (`host=foo dbname=eden user=eden`): install fails at lint
++  time (URL-prefix regex rejects).
+ 
+ Each combination gets a fixture values file under
+ `reference/helm/eden/tests/values/` and a small bash test
+@@ -1458,6 +1581,86 @@
+ is `Delete`. The runbook flags this and recommends `helm
+ upgrade` (NOT `--force`) for the cutover.
+ 
++### 8.3a Sweeper / drain ordering in the migration runbook
++
++The `sweep_expired_claims` step that converts expired
++`claimed` tasks back to `pending` runs inside the
++orchestrator's loop iteration
++([`reference/services/orchestrator/src/eden_orchestrator/loop.py`](../../reference/services/orchestrator/src/eden_orchestrator/loop.py)
++line 67). If the migration runbook scaled the orchestrator
++to zero before workers' claims aged out, the claims would
++stay `claimed` indefinitely and the snapshot would capture
++"in-flight" state that the post-restore deployment cannot
++recover from cleanly (the tasks would be claim-stale on the
++new instance with no orchestrator history to know who held
++them).
++
++§3.8.2 step 1 mitigates this by phasing the scale-down:
++worker hosts to 0 first, wait while the still-running
++orchestrator sweeper drains claims, THEN orchestrator to 0.
++The wait budget is 2× `claim_ttl_seconds` to absorb the
++worst-case "claim made one tick before scale-down". The
++web-ui's admin-reclaim path is a manual escape hatch for any
++claim that hasn't aged out within budget.
++
++A future amendment MAY add an explicit "drain" CLI to the
++orchestrator that sets a "no new claims; finish in-flight
++work; quiesce" mode and exits cleanly, which would let the
++runbook collapse the two-phase scale-down. Out of scope for
++13c; the manual sequence is workable.
++
++### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
++
++Per §3.2.2, the `task-store-server` always sources
++`EDEN_STORE_URL` from a Secret as a single composed URL —
++never composes one at runtime. The contract is uniform:
++the consumed Secret (chart-managed OR `secrets.existingSecret`
++OR `postgres.external.existingSecret`) MUST contain a key
++whose value is a complete `postgresql://...` URL. The chart's
++`secret.yaml` template builds this for the embedded
++chart-managed case; all other cases require the operator to
++pre-populate the key.
++
++**Chart upgrade trap.** 13a's chart did NOT populate
++`EDEN_STORE_URL` in its existingSecret contract — 13a's
++secret.yaml carried postgresPassword + adminToken +
++giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
++(13a §3.2 / §3.3) and built the DSN at chart-template time
++from `postgresPassword`. 13c moves the DSN composition into
++the Secret value itself, which means a 13a operator using
++`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
++MUST add an `EDEN_STORE_URL` key to `my-secret` before the
++upgrade — otherwise the chart-template-time build of the DSN
++no longer happens (because it can't see the password) and the
++task-store-server pod fails to start with an empty
++`EDEN_STORE_URL`.
++
++Mitigations:
++
++- The chart's NOTES.txt at upgrade time emits an explicit
++  warning when `secrets.existingSecret` is set in
++  `mode=embedded`, instructing the operator to add the
++  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
++  contents from the chart, so this is documentation only,
++  not enforcement.)
++- The `migrating-to-managed-postgres.md` runbook adds a
++  pre-upgrade checklist item: "if you use
++  `secrets.existingSecret`, run `kubectl get secret <name> -o
++  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
++  populated; if empty, patch the Secret with the
++  pre-composed DSN before `helm upgrade`".
++- The §6.1 helm-template matrix asserts that the rendered
++  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
++  it cannot assert the Secret's contents.
++
++This trap is the price of the §3.2.2 design choice. The
++alternative — keep template-time DSN composition for
++embedded + chart-managed-secrets, switch to
++"pre-composed-in-Secret" only for external — would split the
++design into two patterns the chart has to maintain. The
++single-pattern shape is worth the one-time upgrade
++documentation.
++
+ ### 8.4 `ensure_schema` on a non-empty managed database
+ 
+ If the operator points `postgres.mode=external` at a
+@@ -1478,25 +1681,29 @@
+ 
+ ### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+ 
+-The Pod spec composes `EDEN_STORE_URL` from
+-`EDEN_STORE_URL_RAW` (from secret) and the TLS suffix.
+-Kubernetes' `$(VAR)` expansion in env values requires
+-`EDEN_STORE_URL_RAW` to be defined BEFORE `EDEN_STORE_URL` in
+-the env list — the
+-[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+-defines `$(VAR)` as expanded against the env vars defined
+-earlier in the same `env:` list. The chart's template MUST
+-order accordingly; ordering will be tested via a `helm
+-template + grep` assertion.
++Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
++as a single pre-composed URL — no template-time DSN
++composition, no `$(VAR)` expansion across env entries, no
++runtime-side string assembly. The chart uses an explicit
++`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
++{name: ..., key: ...}` entry for this specific variable. The
++other deployment credentials (`EDEN_SHARED_TOKEN`,
++`EDEN_SESSION_SECRET`) keep coming through `envFrom:
++secretRef:` from 13a.
+ 
+-If `EDEN_STORE_URL_RAW` comes from `envFrom: secretRef:`, its
+-position in the env-resolution order is implementation-
+-defined. To avoid that risk, the chart uses explicit
+-`env: - name: EDEN_STORE_URL_RAW; valueFrom: secretKeyRef: ...`
+-(NOT `envFrom`) for this specific variable, even when other
+-secrets come through `envFrom`. The other Secret keys
+-(`EDEN_SHARED_TOKEN`, `EDEN_SESSION_SECRET`, etc.) keep using
+-`envFrom`.
++This sidesteps the env-ordering trap that arose when an
++earlier draft tried to compose `EDEN_STORE_URL` from
++`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
++in `args:`: Kubernetes' `$(VAR)` resolution requires the
++referenced variable to be defined earlier in the same `env:`
++list (per the
++[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
++which made the helm-template ordering load-bearing. The
++"single pre-composed value in the Secret" approach removes
++that fragility entirely. The TLS suffix is always baked into
++the Secret value at template time (or, for external +
++`existingSecret` + `tls.enabled`, baked in by the operator
++per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+ 
+ ### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+ 

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2-review.md
@@ -1,0 +1,16 @@
+**1. Missing Context**
+
+Brief assessment: the key context gaps from the prior rounds are addressed. The plan now clearly states the URL-form DSN constraint and correctly frames embedded+`existingSecret` `EDEN_STORE_URL` as a new 13c contract, not inherited from 13a. ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:531))
+
+No significant missing-context issues remain.
+
+**2. Feasibility**
+
+Brief assessment: the design is now broadly feasible, but there are still a couple of concrete binding/example mismatches that I would treat as blocking until fixed, because they sit in the operator runbook and CI shape.
+
+- The direct API reclaim example in the migration runbook does not match the actual wire binding. The plan uses `/v1/tasks?state=claimed` and `POST .../reclaim?cause=operator` in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1030), but the real binding is `GET /v0/experiments/{E}/tasks?state=claimed` and `POST /v0/experiments/{E}/tasks/{T}/reclaim` with JSON body `{"cause":"operator"}` per [07-wire-protocol.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/spec/v0/07-wire-protocol.md:31) and [client.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/packages/eden-wire/src/eden_wire/client.py:301). The post-migration verification example has the same issue: it uses `/v1/events/range` in [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1126), but the actual endpoint is `GET /v0/experiments/{E}/events` with optional `cursor` ([07-wire-protocol.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/spec/v0/07-wire-protocol.md:109), [client.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/packages/eden-wire/src/eden_wire/client.py:195)).
+- The CI section still contradicts its own reachability fix. §8.6 correctly says the sibling Postgres must be addressed by container IP, not `eden-ci-pg` DNS ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1790)), but §3.10’s example still creates the Secret with `postgresql://...@eden-ci-pg:5432/eden` and says that host is reachable from pods ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1223), [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1254)). Those two sections need to converge on the IP-based example.
+
+**Overall Assessment**
+
+The substantive design issues from the first two rounds are resolved. What remains is narrower: the plan still has a few operator/CI examples that do not match the actual wire protocol or the CI networking constraint. I would fix those command-level drifts, then the plan should be ready for a fuller pass on alternatives, completeness, and edge cases.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2.md
@@ -1,0 +1,2036 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       'http://localhost:8080/v1/tasks?state=claimed' \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         "http://localhost:8080/v1/tasks/$tid/reclaim?cause=operator"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Snapshot embedded Postgres via pg_dump.** Run from the
+   operator's workstation:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects same count as before
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly:
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # plus read_range to confirm event count matches:
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer $TOKEN" \
+       http://localhost:8080/v1/events/range
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL='postgresql://eden:ci-test-password@eden-ci-pg:5432/eden'
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at `eden-ci-pg:5432`. This bypasses
+the kind-cluster Service abstraction and proves the
+external-DSN path works against a Postgres the chart did NOT
+create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2.patch
@@ -1,0 +1,233 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/1.md	2026-05-08 12:19:45
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:23:35
+@@ -529,11 +529,18 @@
+   password value the chart owns. The TLS suffix (if any) is
+   appended in the same `printf` call.
+ - **Embedded mode, `secrets.existingSecret`.** The operator's
+-  pre-created Secret MUST already contain `EDEN_STORE_URL`
+-  (the existing 13a §3.3 production-secret contract — verified
+-  by the chart's `existingSecret` documentation). The chart
+-  does NOT compose anything; it just references the
+-  operator-supplied key.
++  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
++  a NEW contract introduced by 13c** — 13a's chart composed
++  the DSN at template time from `secrets.postgresPassword`,
++  so 13a operators using `existingSecret` did NOT need to
++  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
++  the Secret value to avoid the urlquery-without-the-password
++  failure mode (§3.2.2 motivation), so 13a operators upgrading
++  to chart 0.2.0 with `secrets.existingSecret` set MUST add
++  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
++  the upgrade-trap details and the NOTES.txt warning the
++  chart emits. The chart itself does NOT compose anything;
++  it just references the operator-supplied key.
+ - **External mode, `external.connectionString`.** The chart's
+   `secret.yaml` writes the operator-supplied DSN into the
+   chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+@@ -962,19 +969,29 @@
+ between the operator's workstation and BOTH endpoints. The
+ runbook step-by-step:
+ 
+-1. **Drain workers.** Sequencing matters: claim-TTL expiration
+-   is operationalized by the orchestrator's
+-   `sweep_expired_claims` step in
+-   [`reference/services/orchestrator/src/eden_orchestrator/loop.py`](../../reference/services/orchestrator/src/eden_orchestrator/loop.py)
+-   line 67. If the orchestrator is scaled to zero before
+-   in-flight claims expire, no sweeper runs and the
+-   `state=claimed` tasks stay claimed forever. So the drain is
+-   a two-phase scale-down:
++1. **Drain workers.** Sequencing matters because the worker
++   hosts (executor / evaluator / ideator) claim tasks WITHOUT
++   an `expires_at` deadline (verified at
++   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
++   lines 123, 201;
++   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
++   line 164 + sibling files), so the orchestrator's
++   `sweep_expired_claims` at
++   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
++   lines 32-67 SKIPS them — only the Web UI's claim path
++   (which carries a TTL per
++   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
++   line 58) is affected by the sweeper. So the drain is
++   **operator-driven**, not TTL-based. The pattern is:
++   scale workers to 0 (graceful SIGTERM lets each worker
++   finish its in-flight task and submit, transitioning
++   `claimed` → `submitted` for the work that completed
++   within `terminationGracePeriodSeconds`), then operator-
++   reclaim any tasks that didn't finish.
+ 
+-   First, scale the worker hosts (which are the only services
+-   that can newly claim tasks) to zero. Per 13a Decision 3,
+-   `executor-host` / `evaluator-host` / `web-ui` are
+-   StatefulSets and `ideator-host` is a Deployment:
++   Per 13a Decision 3, `executor-host` / `evaluator-host` /
++   `web-ui` are StatefulSets and `ideator-host` is a
++   Deployment:
+ 
+    ```bash
+    kubectl scale statefulset -n eden-prod \
+@@ -985,27 +1002,64 @@
+      --replicas=0
+    ```
+ 
+-   Wait for in-flight tasks to settle. While this drain
+-   proceeds, the orchestrator's running sweeper reclaims
+-   stale claims as TTLs expire. Confirm via the wire
+-   `/admin/tasks/` endpoint that no tasks remain in
+-   `state=claimed`. Budget at least 2× the configured
+-   `claim_ttl_seconds` for the wait. Then scale the
+-   orchestrator to zero:
++   Wait for the StatefulSet / Deployment to report 0 ready
++   replicas (`kubectl rollout status` or polling
++   `kubectl get`). Workers have up to
++   `terminationGracePeriodSeconds` (default 30s) to finish
++   their in-flight task on SIGTERM; any task that did finish
++   transitions to `submitted` via the existing submit path.
++
++   Then operator-reclaim any tasks still in `state=claimed`.
++   Two equivalent paths:
++
++   - **Web-UI admin route** (preferred when operators have
++     UI access): the 9e admin module's per-task detail page
++     exposes a "reclaim" / "force-reclaim (replays work)"
++     button per
++     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
++     (the `Store.reclaim(task_id, "operator")` path per
++     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
++     §5.1). The runbook walks the operator through it
++     task-by-task. The Web UI is still scaled up at this
++     point (scale it to 0 in step 1's third sub-phase).
++   - **Direct API** (for headless operators or when the
++     Web UI is already down): `curl` against the
++     task-store-server's `reclaim` endpoint with the admin
++     bearer:
++
++     ```bash
++     for tid in $(kubectl exec -n eden-prod \
++       deployment/eden-task-store-server -- \
++       curl -s -H "Authorization: Bearer $TOKEN" \
++       'http://localhost:8080/v1/tasks?state=claimed' \
++       | jq -r '.[].task_id'); do
++       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
++         curl -X POST -H "Authorization: Bearer $TOKEN" \
++         "http://localhost:8080/v1/tasks/$tid/reclaim?cause=operator"
++     done
++     ```
++
++   Confirm `state=claimed` is empty via the wire
++   `/admin/tasks/` endpoint or
++   `curl ...?state=claimed | jq length`. Then scale the
++   orchestrator to zero, and the web-ui:
+ 
+    ```bash
+    kubectl scale statefulset -n eden-prod \
+-     eden-orchestrator --replicas=0
++     eden-orchestrator eden-web-ui --replicas=0
+    ```
+ 
+    The `task-store-server` keeps running so we can read its
+    state for the final consistency check before snapshotting.
+-   The web-ui (which can also do operator-driven reclaim per
+-   the 9e admin module) MAY stay up during this window if
+-   operators want to manually reclaim any stuck claim that
+-   hasn't aged out within the budget. Scale it to zero after
+-   the orchestrator if so.
+ 
++   Note that an alternative shape — leaving workers running
++   and capturing `pg_dump` against an active state — is NOT
++   safe: `pg_dump --format=custom` produces an internally
++   consistent snapshot of the SQL state but the Gitea-side
++   git refs the workers may push during the dump are NOT
++   captured, breaking the chapter-6 §3.4 atomicity invariant
++   on restore. The drain is mandatory.
++
+ 2. **Snapshot embedded Postgres via pg_dump.** Run from the
+    operator's workstation:
+ 
+@@ -1581,33 +1635,61 @@
+ is `Delete`. The runbook flags this and recommends `helm
+ upgrade` (NOT `--force`) for the cutover.
+ 
+-### 8.3a Sweeper / drain ordering in the migration runbook
++### 8.3a Drain procedure: operator-driven reclaim, not TTL
+ 
+-The `sweep_expired_claims` step that converts expired
+-`claimed` tasks back to `pending` runs inside the
+-orchestrator's loop iteration
+-([`reference/services/orchestrator/src/eden_orchestrator/loop.py`](../../reference/services/orchestrator/src/eden_orchestrator/loop.py)
+-line 67). If the migration runbook scaled the orchestrator
+-to zero before workers' claims aged out, the claims would
+-stay `claimed` indefinitely and the snapshot would capture
+-"in-flight" state that the post-restore deployment cannot
+-recover from cleanly (the tasks would be claim-stale on the
+-new instance with no orchestrator history to know who held
+-them).
+-
+-§3.8.2 step 1 mitigates this by phasing the scale-down:
+-worker hosts to 0 first, wait while the still-running
+-orchestrator sweeper drains claims, THEN orchestrator to 0.
+-The wait budget is 2× `claim_ttl_seconds` to absorb the
+-worst-case "claim made one tick before scale-down". The
+-web-ui's admin-reclaim path is a manual escape hatch for any
+-claim that hasn't aged out within budget.
++Worker-host claims (executor / evaluator / ideator hosts)
++carry NO `expires_at` field — verified at
++[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
++lines 123 and 201, plus the three subprocess hosts'
++`subprocess_mode.py` files. The orchestrator's
++`sweep_expired_claims` at
++[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
++lines 44-46 explicitly skips claims without an `expires_at`,
++so worker-host claims are NOT TTL-reclaimable. Only the Web
++UI's claim path (per
++[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
++line 58's `--claim-ttl-seconds`) carries an expiry that the
++sweeper acts on.
+ 
+-A future amendment MAY add an explicit "drain" CLI to the
+-orchestrator that sets a "no new claims; finish in-flight
+-work; quiesce" mode and exits cleanly, which would let the
+-runbook collapse the two-phase scale-down. Out of scope for
+-13c; the manual sequence is workable.
++§3.8.2 step 1 reflects this by drainin via two mechanisms,
++not TTL:
++
++1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
++   sends SIGTERM; each pod has up to
++   `terminationGracePeriodSeconds` (k8s default 30s) to
++   finish its in-flight task and submit. Tasks that finish
++   transition `claimed` → `submitted` via the existing
++   wire-side submit path; no operator action needed.
++2. **Operator reclaim for stuck claims.** Any task still in
++   `state=claimed` after worker pods terminate gets
++   reclaimed by the operator via the 9e admin module's
++   `Store.reclaim(task_id, "operator")` path or via direct
++   API call. The orchestrator's sweeper plays no role.
++
++This is materially different from the Web-UI session-
++abandonment recovery flow (which IS TTL-based, per the
++chunk-1 §A "stranded-claim recovery via the sweeper"
++pattern). Operator-driven reclaim is the right mechanism
++for migration drains because it's deterministic + bounded
++in time + doesn't depend on a sweeper that may have already
++been scaled down.
++
++A future amendment MAY add `expires_at` to worker-host
++claims (the spec already supports it on the wire side; only
++the worker-host claim invocation paths omit it), which
++would let the sweeper handle worker-host stuck claims too
++and simplify the runbook. That would be a code change in
++the executor/evaluator/ideator hosts plus the Web UI's
++implementer/evaluator/ideator routes (which currently emit
++TTLs only on the operator-claim path), and a behavior change
++operators would need to opt into. Out of scope for 13c; the
++operator-reclaim path is workable today.
++
++A second future amendment MAY add an explicit "drain" CLI
++to the orchestrator + worker hosts that sets a "no new
++claims; finish in-flight work; quiesce" mode and exits
++cleanly, which would let the runbook collapse the two-phase
++scale-down. Out of scope for 13c.
+ 
+ ### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+ 

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3-review.md
@@ -1,0 +1,14 @@
+**1. Missing Context**
+
+Brief assessment: this is in good shape now. The Secret contract and drain semantics are explicit, and I don’t see any remaining missing-context blockers.
+
+**2. Feasibility**
+
+Brief assessment: the plan is close, but I still see two concrete command/example mismatches that should be fixed before moving on to later review levels.
+
+- The post-migration verification example still doesn’t match the actual `read_range` binding. In [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1142) it calls `GET /v0/experiments/$EID/events?limit=1`, but the wire server only accepts `cursor` on `/events`, not `limit` ([server.py](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/reference/packages/eden-wire/src/eden_wire/server.py:478), [07-wire-protocol.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/spec/v0/07-wire-protocol.md:109)). If the goal is “confirm event count matches the pre-snapshot count,” the sample should use the returned `cursor` from `GET /v0/experiments/$EID/events?cursor=0`, not a nonexistent `limit` parameter.
+- The CI example is still internally inconsistent in one place. The step body now correctly uses `${EDEN_CI_PG_IP}` ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1264), [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1281)), but the explanatory prose right below still says the sibling is reachable from kind pods at `eden-ci-pg:5432` ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1302)). That contradicts §8.6’s correct explanation that CoreDNS will not resolve the Docker container name ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1819)).
+
+**Overall Assessment**
+
+This is much closer. The substantive design issues look resolved; what remains is a last pass on operator/CI example accuracy. I’d fix the `/events` verification command and the lingering `eden-ci-pg:5432` prose, then the plan should be ready for a deeper completeness/edge-case review.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3.md
@@ -1,0 +1,2063 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     # Note: $EID is the chart's --experiment-id (per
+     # setup-experiment-helm.sh / chart values). The actual wire
+     # endpoints live at /v0/experiments/{experiment_id}/... — see
+     # reference/packages/eden-wire/src/eden_wire/server.py line 183
+     # for the base. The reclaim body is a POST JSON body
+     # ({"cause": "operator"}), not a query param.
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"cause": "operator"}' \
+         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Snapshot embedded Postgres via pg_dump.** Run from the
+   operator's workstation:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects same count as before
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly. Endpoint shapes per
+   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+   lines 183-508 (and the `/healthz` endpoint added in 9e):
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # plus read_range to confirm event count matches the pre-snapshot count:
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/events?limit=1" \
+     | jq '.events[0].seq // .events[0].event_id'
+   # variants in success/integrated state:
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/variants?status=success" \
+     | jq length
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+        # Capture the sibling container's IP on the kind network — kind's
+        # CoreDNS does NOT resolve sibling-container names by default
+        # (per §8.6), so the DSN must reference the IP directly. Stash
+        # the IP in $GITHUB_ENV so later steps see it.
+        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
+        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        # Use the sibling Postgres' IP (captured above), NOT
+        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
+        # for in-cluster Services; a host on the kind Docker network
+        # is reachable by IP but not by docker container name from
+        # inside pods. See §8.6.
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at `eden-ci-pg:5432`. This bypasses
+the kind-cluster Service abstraction and proves the
+external-DSN path works against a Postgres the chart did NOT
+create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3.patch
@@ -1,0 +1,83 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/2.md	2026-05-08 12:23:51
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:25:22
+@@ -1028,14 +1028,22 @@
+      bearer:
+ 
+      ```bash
++     # Note: $EID is the chart's --experiment-id (per
++     # setup-experiment-helm.sh / chart values). The actual wire
++     # endpoints live at /v0/experiments/{experiment_id}/... — see
++     # reference/packages/eden-wire/src/eden_wire/server.py line 183
++     # for the base. The reclaim body is a POST JSON body
++     # ({"cause": "operator"}), not a query param.
+      for tid in $(kubectl exec -n eden-prod \
+        deployment/eden-task-store-server -- \
+        curl -s -H "Authorization: Bearer $TOKEN" \
+-       'http://localhost:8080/v1/tasks?state=claimed' \
++       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+        | jq -r '.[].task_id'); do
+        kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+          curl -X POST -H "Authorization: Bearer $TOKEN" \
+-         "http://localhost:8080/v1/tasks/$tid/reclaim?cause=operator"
++         -H "Content-Type: application/json" \
++         -d '{"cause": "operator"}' \
++         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+      done
+      ```
+ 
+@@ -1124,15 +1132,23 @@
+    already populated and is a no-op.
+ 
+ 7. **Post-migration verification.** Hit the wire endpoint
+-   directly:
++   directly. Endpoint shapes per
++   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
++   lines 183-508 (and the `/healthz` endpoint added in 9e):
+ 
+    ```bash
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+      curl -s http://localhost:8080/healthz
+-   # plus read_range to confirm event count matches:
++   # plus read_range to confirm event count matches the pre-snapshot count:
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+      curl -s -H "Authorization: Bearer $TOKEN" \
+-       http://localhost:8080/v1/events/range
++       "http://localhost:8080/v0/experiments/$EID/events?limit=1" \
++     | jq '.events[0].seq // .events[0].event_id'
++   # variants in success/integrated state:
++   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
++     curl -s -H "Authorization: Bearer $TOKEN" \
++       "http://localhost:8080/v0/experiments/$EID/variants?status=success" \
++     | jq length
+    ```
+ 
+ 8. **Scale workers back up.** Reverse-order from step 1: bring
+@@ -1241,6 +1257,12 @@
+           docker exec eden-ci-pg pg_isready -U eden -d eden && break
+           sleep 1
+         done
++        # Capture the sibling container's IP on the kind network — kind's
++        # CoreDNS does NOT resolve sibling-container names by default
++        # (per §8.6), so the DSN must reference the IP directly. Stash
++        # the IP in $GITHUB_ENV so later steps see it.
++        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
++        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+     - name: Build + load chart's image into kind
+       run: |
+         docker build -t eden-reference:dev \
+@@ -1249,9 +1271,14 @@
+     - name: Helm install with mode=external
+       run: |
+         kubectl create namespace eden-test
++        # Use the sibling Postgres' IP (captured above), NOT
++        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
++        # for in-cluster Services; a host on the kind Docker network
++        # is reachable by IP but not by docker container name from
++        # inside pods. See §8.6.
+         kubectl create secret generic eden-managed-pg \
+           -n eden-test \
+-          --from-literal=EDEN_STORE_URL='postgresql://eden:ci-test-password@eden-ci-pg:5432/eden'
++          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+         helm install eden ./reference/helm/eden \
+           -f reference/helm/eden/ci-values-managed-postgres.yaml \
+           -n eden-test --wait --timeout 5m

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4-review.md
@@ -1,0 +1,15 @@
+**1. Missing Context**
+
+Brief assessment: no new missing-context issues. The revised Secret contract and drain semantics are clear.
+
+**2. Feasibility**
+
+I still have one substantive feasibility finding, so I would stop here rather than move on to alternatives/completeness.
+
+- The new cursor-walking verification example still won’t work as written because `$TOKEN` is expanded in the wrong shell. In [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1151), the `kubectl exec ... bash -c '...'` script is single-quoted, so `$TOKEN` is **not** expanded on the operator side; it will only be expanded inside the container, where that env var is not present. The result is an empty bearer token in the inner `curl`. `$EID` is handled by breaking out of the single quotes, but `$TOKEN` is not. This runbook snippet needs either:
+  - outer-shell expansion for both `$TOKEN` and `$EID`, or
+  - an explicit way to pass `TOKEN` into the exec’d shell.
+
+**Overall Assessment**
+
+This is very close, but I would not call convergence yet because the operator verification snippet is still not executable as written. Once that shell-expansion bug is fixed, I’d be comfortable moving on to levels 3-5.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4.md
@@ -1,0 +1,2085 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     # Note: $EID is the chart's --experiment-id (per
+     # setup-experiment-helm.sh / chart values). The actual wire
+     # endpoints live at /v0/experiments/{experiment_id}/... — see
+     # reference/packages/eden-wire/src/eden_wire/server.py line 183
+     # for the base. The reclaim body is a POST JSON body
+     # ({"cause": "operator"}), not a query param.
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"cause": "operator"}' \
+         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Snapshot embedded Postgres via pg_dump.** Run from the
+   operator's workstation:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects same count as before
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly. Endpoint shapes per
+   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+   lines 183-508 (and the `/healthz` endpoint added in 9e).
+   The `/v0/experiments/{E}/events` endpoint paginates via a
+   `cursor` query param (not `limit`); to confirm event-count
+   parity with the pre-snapshot state, walk the cursor or
+   simply count the response on a fresh deployment where it
+   fits in one page.
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # Walk the events cursor to count total events, comparing
+   # against the pre-snapshot count captured before pg_dump.
+   # cursor=0 returns the first batch; the response includes a
+   # forward `cursor` to feed the next call.
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/'$EID'/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "events: $count"'
+   # Variants in success status (sanity-check a non-zero count
+   # for any non-trivial experiment):
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/variants?status=success" \
+     | jq length
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+        # Capture the sibling container's IP on the kind network — kind's
+        # CoreDNS does NOT resolve sibling-container names by default
+        # (per §8.6), so the DSN must reference the IP directly. Stash
+        # the IP in $GITHUB_ENV so later steps see it.
+        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
+        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        # Use the sibling Postgres' IP (captured above), NOT
+        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
+        # for in-cluster Services; a host on the kind Docker network
+        # is reachable by IP but not by docker container name from
+        # inside pods. See §8.6.
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at the container's IP on that network
+(captured into `${EDEN_CI_PG_IP}` above). The kind cluster's
+CoreDNS does NOT resolve sibling-container names — see §8.6 —
+so the DSN MUST embed the IP, not `eden-ci-pg`. The IP-based
+path bypasses the kind-cluster Service abstraction and proves
+the external-DSN path works against a Postgres the chart did
+NOT create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4.patch
@@ -1,0 +1,63 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/3.md	2026-05-08 12:25:37
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:26:53
+@@ -1134,17 +1134,36 @@
+ 7. **Post-migration verification.** Hit the wire endpoint
+    directly. Endpoint shapes per
+    [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+-   lines 183-508 (and the `/healthz` endpoint added in 9e):
++   lines 183-508 (and the `/healthz` endpoint added in 9e).
++   The `/v0/experiments/{E}/events` endpoint paginates via a
++   `cursor` query param (not `limit`); to confirm event-count
++   parity with the pre-snapshot state, walk the cursor or
++   simply count the response on a fresh deployment where it
++   fits in one page.
+ 
+    ```bash
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+      curl -s http://localhost:8080/healthz
+-   # plus read_range to confirm event count matches the pre-snapshot count:
++   # Walk the events cursor to count total events, comparing
++   # against the pre-snapshot count captured before pg_dump.
++   # cursor=0 returns the first batch; the response includes a
++   # forward `cursor` to feed the next call.
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+-     curl -s -H "Authorization: Bearer $TOKEN" \
+-       "http://localhost:8080/v0/experiments/$EID/events?limit=1" \
+-     | jq '.events[0].seq // .events[0].event_id'
+-   # variants in success/integrated state:
++     bash -c '
++       count=0; cursor=0;
++       while :; do
++         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
++           "http://localhost:8080/v0/experiments/'$EID'/events?cursor=$cursor")
++         batch=$(echo "$resp" | jq ".events | length")
++         count=$((count + batch))
++         next=$(echo "$resp" | jq ".cursor")
++         [ "$batch" = "0" ] && break
++         [ "$next" = "$cursor" ] && break
++         cursor=$next
++       done
++       echo "events: $count"'
++   # Variants in success status (sanity-check a non-zero count
++   # for any non-trivial experiment):
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+      curl -s -H "Authorization: Bearer $TOKEN" \
+        "http://localhost:8080/v0/experiments/$EID/variants?status=success" \
+@@ -1301,10 +1320,13 @@
+ 
+ The `kind` cluster's network is `kind` (Docker network created
+ by kind-action); a sibling container on the same network is
+-reachable from kind pods at `eden-ci-pg:5432`. This bypasses
+-the kind-cluster Service abstraction and proves the
+-external-DSN path works against a Postgres the chart did NOT
+-create.
++reachable from kind pods at the container's IP on that network
++(captured into `${EDEN_CI_PG_IP}` above). The kind cluster's
++CoreDNS does NOT resolve sibling-container names — see §8.6 —
++so the DSN MUST embed the IP, not `eden-ci-pg`. The IP-based
++path bypasses the kind-cluster Service abstraction and proves
++the external-DSN path works against a Postgres the chart did
++NOT create.
+ 
+ `ci-values-managed-postgres.yaml` (new) sets:
+ 

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5-review.md
@@ -1,0 +1,23 @@
+Levels 1-2 look converged now, so I continued.
+
+**3. Alternatives**
+
+Brief assessment: the chosen approach still looks like the right one. Keeping 13c as a chart/runbook substrate change, with full DSNs stored in Secrets and no bundled migration tool or pooler, is the best fit for the current codebase and scope. I don’t see a better alternative that preserves the “no code changes” goal.
+
+No substantive alternatives findings.
+
+**4. Completeness**
+
+I have one remaining substantive completeness issue:
+
+- The migration runbook now tells the operator to compare the restored/post-upgrade event count against a pre-snapshot baseline, but it never actually includes a step that captures that baseline before `pg_dump`. Step 4 says `SELECT count(*) FROM event; -- expects same count as before`, and step 7 says to compare against “the pre-snapshot count captured before pg_dump,” but no earlier step records it. ([eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1103), [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1147)) Add one explicit pre-snapshot command in step 1 or step 2 to record the source event count, either from SQL or from the wire endpoint’s returned `cursor`.
+
+**5. Edge Cases and Risks**
+
+Brief assessment: the risk coverage is otherwise strong. The document now explicitly covers the real sharp edges: worker-host claims without TTL, the 13a `existingSecret` upgrade trap, external-secret TLS suffix ownership, and kind CoreDNS limitations.
+
+No additional substantive edge-case findings beyond the completeness issue above.
+
+**Overall Assessment**
+
+This is very close. I would not call full convergence yet because the runbook still relies on a pre-snapshot event-count baseline that it never instructs the operator to capture. Once that explicit baseline-capture step is added, I’d consider the plan converged.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5.md
@@ -1,0 +1,2095 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     # Note: $EID is the chart's --experiment-id (per
+     # setup-experiment-helm.sh / chart values). The actual wire
+     # endpoints live at /v0/experiments/{experiment_id}/... — see
+     # reference/packages/eden-wire/src/eden_wire/server.py line 183
+     # for the base. The reclaim body is a POST JSON body
+     # ({"cause": "operator"}), not a query param.
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"cause": "operator"}' \
+         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Snapshot embedded Postgres via pg_dump.** Run from the
+   operator's workstation:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects same count as before
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly. Endpoint shapes per
+   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+   lines 183-508 (and the `/healthz` endpoint added in 9e).
+   The `/v0/experiments/{E}/events` endpoint paginates via a
+   `cursor` query param (not `limit`); to confirm event-count
+   parity with the pre-snapshot state, walk the cursor or
+   simply count the response on a fresh deployment where it
+   fits in one page.
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # Walk the events cursor to count total events, comparing
+   # against the pre-snapshot count captured before pg_dump.
+   # cursor=0 returns the first batch; the response includes a
+   # forward `cursor` to feed the next call.
+   #
+   # Both $TOKEN and $EID are operator-side env vars; pass them
+   # explicitly via `env` to the kubectl-exec'd shell so the
+   # double-quoted bash -c string sees the right values. (A
+   # single-quoted bash -c body would not expand $TOKEN at all;
+   # a double-quoted body with no `env` would expand $TOKEN on
+   # the operator side, which is what we want — but using `env`
+   # makes the boundary explicit.)
+   kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "events: $count"'
+   # Variants in success status (sanity-check a non-zero count
+   # for any non-trivial experiment). Operator-side $TOKEN and
+   # $EID expansion (no `env` passthrough needed — single curl
+   # call resolved by the outer shell):
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer ${TOKEN}" \
+       "http://localhost:8080/v0/experiments/${EID}/variants?status=success" \
+     | jq length
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+        # Capture the sibling container's IP on the kind network — kind's
+        # CoreDNS does NOT resolve sibling-container names by default
+        # (per §8.6), so the DSN must reference the IP directly. Stash
+        # the IP in $GITHUB_ENV so later steps see it.
+        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
+        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        # Use the sibling Postgres' IP (captured above), NOT
+        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
+        # for in-cluster Services; a host on the kind Docker network
+        # is reachable by IP but not by docker container name from
+        # inside pods. See §8.6.
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at the container's IP on that network
+(captured into `${EDEN_CI_PG_IP}` above). The kind cluster's
+CoreDNS does NOT resolve sibling-container names — see §8.6 —
+so the DSN MUST embed the IP, not `eden-ci-pg`. The IP-based
+path bypasses the kind-cluster Service abstraction and proves
+the external-DSN path works against a Postgres the chart did
+NOT create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5.patch
@@ -1,0 +1,42 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/4.md	2026-05-08 12:27:09
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:29:03
+@@ -1148,12 +1148,20 @@
+    # against the pre-snapshot count captured before pg_dump.
+    # cursor=0 returns the first batch; the response includes a
+    # forward `cursor` to feed the next call.
+-   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+-     bash -c '
++   #
++   # Both $TOKEN and $EID are operator-side env vars; pass them
++   # explicitly via `env` to the kubectl-exec'd shell so the
++   # double-quoted bash -c string sees the right values. (A
++   # single-quoted bash -c body would not expand $TOKEN at all;
++   # a double-quoted body with no `env` would expand $TOKEN on
++   # the operator side, which is what we want — but using `env`
++   # makes the boundary explicit.)
++   kubectl exec -n eden-prod deployment/eden-task-store-server \
++     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+        count=0; cursor=0;
+        while :; do
+          resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+-           "http://localhost:8080/v0/experiments/'$EID'/events?cursor=$cursor")
++           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+          batch=$(echo "$resp" | jq ".events | length")
+          count=$((count + batch))
+          next=$(echo "$resp" | jq ".cursor")
+@@ -1163,10 +1171,12 @@
+        done
+        echo "events: $count"'
+    # Variants in success status (sanity-check a non-zero count
+-   # for any non-trivial experiment):
++   # for any non-trivial experiment). Operator-side $TOKEN and
++   # $EID expansion (no `env` passthrough needed — single curl
++   # call resolved by the outer shell):
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+-     curl -s -H "Authorization: Bearer $TOKEN" \
+-       "http://localhost:8080/v0/experiments/$EID/variants?status=success" \
++     curl -s -H "Authorization: Bearer ${TOKEN}" \
++       "http://localhost:8080/v0/experiments/${EID}/variants?status=success" \
+      | jq length
+    ```
+ 

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6-review.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6-review.md
@@ -1,0 +1,3 @@
+No further substantive findings. The plan has converged.
+
+One non-blocking editorial cleanup remains: two references still say “step 1a” even though the baseline capture now lives in step 2. See [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1140) and [eden-phase-13c-managed-postgres.md](/Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md:1193). That doesn’t change my convergence call.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6.md
@@ -1,0 +1,2140 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     # Note: $EID is the chart's --experiment-id (per
+     # setup-experiment-helm.sh / chart values). The actual wire
+     # endpoints live at /v0/experiments/{experiment_id}/... — see
+     # reference/packages/eden-wire/src/eden_wire/server.py line 183
+     # for the base. The reclaim body is a POST JSON body
+     # ({"cause": "operator"}), not a query param.
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"cause": "operator"}' \
+         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Capture pre-snapshot baselines, then `pg_dump`.** Before
+   `pg_dump` runs, record the event count and the highest event
+   seq from the embedded Postgres. Step 4's SQL verification
+   and step 7's wire-endpoint verification both compare against
+   these baselines. The `task-store-server` is still running at
+   this point.
+
+   ```bash
+   # SQL-side baseline (queried directly against the embedded pod):
+   EVENT_COUNT_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
+     psql --user=eden --dbname=eden -tAc 'SELECT count(*) FROM event;')
+   MAX_SEQ_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
+     psql --user=eden --dbname=eden -tAc 'SELECT COALESCE(MAX(seq), 0) FROM event;')
+   echo "baseline: events=$EVENT_COUNT_BEFORE max_seq=$MAX_SEQ_BEFORE"
+
+   # Wire-side baseline (cursor walk; same shape as step 7's
+   # post-migration check). Captures the same count via the
+   # public surface so the post-migration verification can be
+   # apples-to-apples even if the operator can't shell into
+   # the new Postgres directly.
+   WIRE_COUNT_BEFORE=$(kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "$count"')
+   echo "wire-baseline events: $WIRE_COUNT_BEFORE"
+   ```
+
+   Save these three numbers. (Wire-side count and SQL-side
+   count SHOULD match for a quiesced experiment; if they
+   diverge, investigate before snapshotting — likely indicates
+   an in-flight write that the step-1 drain didn't catch.)
+
+   Then run `pg_dump`:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm against the baselines captured
+   in step 1a:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects EVENT_COUNT_BEFORE
+   SELECT COALESCE(MAX(seq), 0) FROM event;
+   -- expects MAX_SEQ_BEFORE
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly. Endpoint shapes per
+   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+   lines 183-508 (and the `/healthz` endpoint added in 9e).
+   The `/v0/experiments/{E}/events` endpoint paginates via a
+   `cursor` query param (not `limit`); to confirm event-count
+   parity with the pre-snapshot state, walk the cursor or
+   simply count the response on a fresh deployment where it
+   fits in one page.
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # Walk the events cursor to count total events. Compare
+   # the result against the wire-side baseline captured in
+   # step 1a (the "wire-baseline events:" line).
+   # cursor=0 returns the first batch; the response includes a
+   # forward `cursor` to feed the next call.
+   #
+   # Both $TOKEN and $EID are operator-side env vars; pass them
+   # explicitly via `env` to the kubectl-exec'd shell so the
+   # double-quoted bash -c string sees the right values. (A
+   # single-quoted bash -c body would not expand $TOKEN at all;
+   # a double-quoted body with no `env` would expand $TOKEN on
+   # the operator side, which is what we want — but using `env`
+   # makes the boundary explicit.)
+   kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "events: $count"'
+   # Variants in success status (sanity-check a non-zero count
+   # for any non-trivial experiment). Operator-side $TOKEN and
+   # $EID expansion (no `env` passthrough needed — single curl
+   # call resolved by the outer shell):
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer ${TOKEN}" \
+       "http://localhost:8080/v0/experiments/${EID}/variants?status=success" \
+     | jq length
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+        # Capture the sibling container's IP on the kind network — kind's
+        # CoreDNS does NOT resolve sibling-container names by default
+        # (per §8.6), so the DSN must reference the IP directly. Stash
+        # the IP in $GITHUB_ENV so later steps see it.
+        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
+        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        # Use the sibling Postgres' IP (captured above), NOT
+        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
+        # for in-cluster Services; a host on the kind Docker network
+        # is reachable by IP but not by docker container name from
+        # inside pods. See §8.6.
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at the container's IP on that network
+(captured into `${EDEN_CI_PG_IP}` above). The kind cluster's
+CoreDNS does NOT resolve sibling-container names — see §8.6 —
+so the DSN MUST embed the IP, not `eden-ci-pg`. The IP-based
+path bypasses the kind-cluster Service abstraction and proves
+the external-DSN path works against a Postgres the chart did
+NOT create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6.patch
@@ -1,0 +1,87 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/5.md	2026-05-08 12:29:27
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:31:33
+@@ -1068,10 +1068,51 @@
+    captured, breaking the chapter-6 §3.4 atomicity invariant
+    on restore. The drain is mandatory.
+ 
+-2. **Snapshot embedded Postgres via pg_dump.** Run from the
+-   operator's workstation:
++2. **Capture pre-snapshot baselines, then `pg_dump`.** Before
++   `pg_dump` runs, record the event count and the highest event
++   seq from the embedded Postgres. Step 4's SQL verification
++   and step 7's wire-endpoint verification both compare against
++   these baselines. The `task-store-server` is still running at
++   this point.
+ 
+    ```bash
++   # SQL-side baseline (queried directly against the embedded pod):
++   EVENT_COUNT_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
++     psql --user=eden --dbname=eden -tAc 'SELECT count(*) FROM event;')
++   MAX_SEQ_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
++     psql --user=eden --dbname=eden -tAc 'SELECT COALESCE(MAX(seq), 0) FROM event;')
++   echo "baseline: events=$EVENT_COUNT_BEFORE max_seq=$MAX_SEQ_BEFORE"
++
++   # Wire-side baseline (cursor walk; same shape as step 7's
++   # post-migration check). Captures the same count via the
++   # public surface so the post-migration verification can be
++   # apples-to-apples even if the operator can't shell into
++   # the new Postgres directly.
++   WIRE_COUNT_BEFORE=$(kubectl exec -n eden-prod deployment/eden-task-store-server \
++     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
++       count=0; cursor=0;
++       while :; do
++         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
++           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
++         batch=$(echo "$resp" | jq ".events | length")
++         count=$((count + batch))
++         next=$(echo "$resp" | jq ".cursor")
++         [ "$batch" = "0" ] && break
++         [ "$next" = "$cursor" ] && break
++         cursor=$next
++       done
++       echo "$count"')
++   echo "wire-baseline events: $WIRE_COUNT_BEFORE"
++   ```
++
++   Save these three numbers. (Wire-side count and SQL-side
++   count SHOULD match for a quiesced experiment; if they
++   diverge, investigate before snapshotting — likely indicates
++   an in-flight write that the step-1 drain didn't catch.)
++
++   Then run `pg_dump`:
++
++   ```bash
+    kubectl exec -n eden-prod eden-postgres-0 -- \
+      pg_dump --format=custom --no-owner --no-acl \
+        --user=eden --dbname=eden \
+@@ -1095,13 +1136,16 @@
+    non-superusers, ensure the database exists first.
+ 
+ 4. **Verify the schema_version round-trip.** Connect to the
+-   managed instance and confirm:
++   managed instance and confirm against the baselines captured
++   in step 1a:
+ 
+    ```sql
+    SELECT MAX(version) FROM schema_version;
+    -- expects 1
+    SELECT count(*) FROM event;
+-   -- expects same count as before
++   -- expects EVENT_COUNT_BEFORE
++   SELECT COALESCE(MAX(seq), 0) FROM event;
++   -- expects MAX_SEQ_BEFORE
+    ```
+ 
+ 5. **Swap the chart values.** Edit `values.yaml` to set
+@@ -1144,8 +1188,9 @@
+    ```bash
+    kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+      curl -s http://localhost:8080/healthz
+-   # Walk the events cursor to count total events, comparing
+-   # against the pre-snapshot count captured before pg_dump.
++   # Walk the events cursor to count total events. Compare
++   # the result against the wire-side baseline captured in
++   # step 1a (the "wire-baseline events:" line).
+    # cursor=0 returns the first batch; the response includes a
+    # forward `cursor` to feed the next call.
+    #

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/7.md
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/7.md
@@ -1,0 +1,2140 @@
+# Phase 13c — Managed Postgres migration
+
+**Status.** Draft.
+
+**Predecessor.** [`docs/plans/eden-phase-13a-helm-base-chart.md`](eden-phase-13a-helm-base-chart.md)
+(merged) and [`docs/plans/eden-phase-13b-executor-k8s-job.md`](eden-phase-13b-executor-k8s-job.md)
+(merged). 13a established the base Helm chart with an in-cluster
+Postgres `StatefulSet` as a stopgap (13a §3.4 and Decision 8); 13a
+§4.2 explicitly punted "managed Postgres migration" to 13c. 13b
+added an executor mode and made no changes to the storage backend
+or the `task-store-server`'s DSN handling, so 13c starts from the
+same `EDEN_STORE_URL` knob 13a wires through.
+
+**Roadmap.** [`docs/roadmap.md`](../roadmap.md) §"Phase 13 —
+Kubernetes reference deployment" lists "Managed Postgres
+migration" as one of the four post-13a sub-projects. 13c is the
+**third** chunk in the substrate sequence (13a → 13b → 13c → 13d
+→ 13e).
+
+**Naming.** Pre-draft check against
+[`docs/glossary.md`](../glossary.md) and AGENTS.md "Naming discipline":
+
+- "Postgres", "DSN", "RDS", "Cloud SQL", "AlloyDB" are upstream
+  vocabulary; no collisions with EDEN identifiers.
+- The chart's existing knob is `EDEN_STORE_URL` (compose `.env`)
+  rendered as `config.storeUrl` in the Helm values surface (13a
+  §3.2). 13c does NOT introduce a separate `postgres.dsn` key —
+  the existing `EDEN_STORE_URL` is the one wire-format the
+  task-store-server already understands ([`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+  lines 37-57). The new value 13c adds is a discriminator
+  (`postgres.mode ∈ {embedded, external}`) plus the
+  `postgres.external.*` block; the rendered `EDEN_STORE_URL`
+  comes from one source or the other depending on the
+  discriminator.
+- No EDEN protocol vocabulary changes. Pre-submit
+  `scripts/check-rename-discipline.py` clean.
+
+## 1. Context
+
+### 1.0 Substrate baseline (post-13a / 13b)
+
+After 13a + 13b the reference k8s deployment runs:
+
+- An **in-cluster Postgres `StatefulSet`** (13a §3.4 and §5.1) at
+  the chart-managed name `<release>-eden-postgres-0`, image
+  `postgres:16.6-alpine`, backed by a PVC sized
+  `storage.postgresSize` (default `10Gi`) on the cluster's default
+  `StorageClass`. Replicas: 1.
+- A chart-managed `Secret` named `<release>-eden-secrets` (or
+  `secrets.existingSecret` per 13a §3.3) carrying
+  `secrets.postgresPassword` plus the rest of the deployment
+  credentials.
+- The `task-store-server` Deployment passes
+  `--store-url $(EDEN_STORE_URL)` where `EDEN_STORE_URL` is
+  injected from the Secret as
+  `postgresql://eden:<password>@<release>-eden-postgres:5432/eden`
+  (the chart's `_helpers.tpl` builds this).
+- Schema bootstrap is byte-for-byte the same as Compose's: on
+  first connection [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py)
+  `ensure_schema(conn)` runs the linear migration list under a
+  bootstrap `schema_version` table, idempotent on re-run.
+- No connection pooler. The `PostgresStore` opens **one psycopg
+  connection per process** ([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+  line 152) and serializes calls behind a process-internal
+  `RLock`. The task-store-server is a single-replica Deployment
+  in 13a (`replicas.taskStoreServer: 1`); only one connection
+  hits Postgres.
+- Compose deployment retains the same in-stack Postgres service
+  ([`reference/compose/compose.yaml`](../../reference/compose/compose.yaml)
+  lines 4-30). `setup-experiment.sh` writes `EDEN_STORE_URL` into
+  `.env` from the auto-generated `POSTGRES_PASSWORD`
+  ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+  lines 286-293).
+
+13c's job is to add a **second** Postgres provisioning mode to
+the chart — `postgres.mode=external` — that points the
+task-store-server at a managed Postgres instance the operator has
+provisioned out-of-band (RDS, Cloud SQL, AlloyDB, Supabase,
+Neon, Crunchy Bridge, etc.). Both modes coexist; the operator
+picks per release. The Compose deployment is unchanged — Compose
+keeps the in-stack Postgres for local development.
+
+### 1.1 What 13c changes
+
+13c adds:
+
+1. A new `postgres.mode` chart value, an enum
+   `∈ {embedded, external}`. Default `embedded` (preserves 13a
+   behavior exactly — chart upgrade from 13a to 13c is a no-op
+   for any operator who doesn't opt in).
+2. A new `postgres.external` values block carrying the connection
+   string, optional CA bundle for TLS verification, and optional
+   `existingSecret` reference.
+3. Conditional rendering on `postgres.mode`:
+   - `embedded`: render `postgres-statefulset.yaml`,
+     `postgres-service.yaml` (the existing 13a templates) — no
+     change.
+   - `external`: skip the StatefulSet + Service entirely; instead
+     wire the task-store-server's `EDEN_STORE_URL` env var to the
+     external DSN.
+4. A `values.schema.json` clause that fails `helm install` /
+   `helm template` at lint time when `postgres.mode=external` and
+   the DSN is empty — the AGENTS.md substrate-plan pitfall on
+   "no fictional defaults for operator-required values".
+5. **No bundled migration tool.** The existing `ensure_schema`
+   bootstrap stays the canonical schema-management mechanism.
+   The plan §3.5 explains why deferring Alembic/sqitch to a
+   future chunk is the right call.
+6. **No connection pooler in v0.** The `task-store-server` is a
+   single-replica Deployment with one connection per process; a
+   pooler is unnecessary at this scale. The plan §3.4 documents
+   the threshold at which a pooler becomes load-bearing (and
+   what 13c does to keep that surface easy to add later).
+7. A new opt-in `postgres.tls` value block for managed-Postgres
+   deployments that require TLS verification (RDS / Cloud SQL
+   typically do). The chart mounts a CA bundle from the secret
+   into the task-store-server pod and passes
+   `?sslmode=verify-full&sslrootcert=<path>` to psycopg via
+   `EDEN_STORE_URL`.
+8. A migration **runbook** at `docs/deployment/migrating-to-managed-postgres.md`
+   covering `pg_dump`/`pg_restore` with EDEN-specific
+   pre-conditions (drain workers, snapshot the in-cluster
+   Postgres, verify schema version round-trips, swap the chart
+   value, rolling-restart the task-store-server). The runbook is
+   docs only — no scripted automation in v0.
+9. A new CI job `helm-smoke-managed-postgres` that mirrors
+   13a's `helm-smoke` but stands up an out-of-cluster Postgres
+   container alongside the kind cluster, deploys the chart with
+   `postgres.mode=external`, and asserts the same end-state
+   invariants (≥3 `variant.integrated` events, ≥9
+   `task.completed` events, etc.) — proving the
+   managed-Postgres path drives an experiment to quiescence
+   identically.
+
+13c does NOT change:
+
+- The Compose deployment. Compose keeps its in-stack Postgres.
+- The `PostgresStore` code. The DSN flows through unchanged;
+  managed Postgres is a deployment-substrate change only.
+- The wire protocol or any conformance scenario. The protocol
+  is binding-agnostic; backend choice doesn't surface on the
+  wire.
+- Backups. Managed providers have their own backup mechanisms;
+  EDEN documents what to back up but does not script anything.
+- Replication or read-replicas. Single writer in v0;
+  read-replicas are documented as a future amendment.
+
+### 1.2 Spec baseline + reconciliation
+
+13c touches no normative spec text. Chapter 8 §3
+([`spec/v0/08-storage.md`](../../spec/v0/08-storage.md)) requires
+the Store be durable across restarts, atomic per the §1.2
+"composite-commit" rule, and read-after-write consistent (§3.2);
+managed Postgres satisfies all three by construction (it's still
+Postgres). Chapter 8 §7's implementation latitude already permits
+"any backend conforming to the `Store` Protocol", and
+`PostgresStore` itself is unchanged in 13c.
+
+| Existing artifact | 13c disposition |
+|---|---|
+| [`spec/v0/08-storage.md`](../../spec/v0/08-storage.md) | Unchanged. |
+| [`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py) | Unchanged. The DSN is the only knob; managed Postgres uses the same code path. |
+| [`reference/packages/eden-storage/src/eden_storage/_postgres_schema.py`](../../reference/packages/eden-storage/src/eden_storage/_postgres_schema.py) | Unchanged. `ensure_schema` is the schema bootstrap; managed providers run it on first connection same as embedded. |
+| [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py) | Unchanged. `build_store` already dispatches on `store_url` scheme. |
+| [`reference/helm/eden/values.yaml`](../../reference/helm/eden/values.yaml) | Adds `postgres.mode`, `postgres.external.*`, `postgres.tls.*` blocks. |
+| [`reference/helm/eden/templates/postgres-statefulset.yaml`](../../reference/helm/eden/templates/postgres-statefulset.yaml) | Wraps in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| [`reference/helm/eden/templates/postgres-service.yaml`](../../reference/helm/eden/templates/postgres-service.yaml) | Same conditional. |
+| [`reference/helm/eden/templates/_helpers.tpl`](../../reference/helm/eden/templates/_helpers.tpl) | Adds `eden.storeUrl` helper that returns the embedded-mode-built DSN OR the external DSN per `postgres.mode`. The `task-store-server` Deployment template references this helper instead of hard-coding the embedded host. |
+| [`reference/compose/compose.yaml`](../../reference/compose/compose.yaml) | Unchanged. Compose keeps the in-stack Postgres service. |
+| [`reference/compose/.env.example`](../../reference/compose/.env.example) | Unchanged for default behavior; a comment block documents that an operator MAY substitute a managed-Postgres DSN by hand-editing `EDEN_STORE_URL` after `setup-experiment.sh` runs (no script support — Compose is the dev path). |
+
+### 1.3 Naming-discipline baseline
+
+PR #60's strengthened guardrail applies. New identifiers
+introduced by 13c:
+
+- Chart values: `postgres.mode`, `postgres.embedded.*` (a
+  rename of the existing flat `postgres.*` 13a fields under an
+  `embedded` namespace — see §3.1.2 for the migration shape),
+  `postgres.external.connectionString`,
+  `postgres.external.existingSecret`,
+  `postgres.external.connectionStringKey`,
+  `postgres.external.tlsAlreadyEncodedInSecret`,
+  `postgres.tls.enabled`, `postgres.tls.caBundleSecret`,
+  `postgres.tls.caBundleKey`, `postgres.tls.mode`.
+- Helm helpers: `eden.storeUrl` (in `_helpers.tpl`).
+- New CI job name: `helm-smoke-managed-postgres`.
+- New runbook: `docs/deployment/migrating-to-managed-postgres.md`.
+
+None of these reintroduce retired vocabulary (`promote`,
+`eval_error`, verb-on-verb helpers); pre-submit
+`scripts/check-rename-discipline.py` clean.
+
+## 2. Decisions
+
+These are the load-bearing design calls; §3 unpacks each.
+
+1. **Two coexisting Postgres modes via a `postgres.mode` enum,
+   default `embedded`.** The chart's `postgres.mode ∈ {embedded,
+   external}` switch picks between the 13a-bundled
+   `StatefulSet` and an operator-provisioned managed Postgres
+   referenced by DSN. Default is `embedded` — chart upgrade from
+   13a to 13c is a no-op for any operator who doesn't opt in.
+   Rejected: making the chart EXTERNAL-by-default with the
+   embedded path as opt-in (would break every existing 13a
+   deployment on chart upgrade); deleting the embedded path
+   entirely (would force every operator off greenfield clusters
+   onto a managed provider before they even have a working
+   stack). See §3.1.
+
+2. **DSN is operator-supplied. No fictional default.** When
+   `postgres.mode=external`, `postgres.external.connectionString`
+   (or `postgres.external.existingSecret` referencing a Secret
+   key) MUST be non-empty — `values.schema.json`'s `if/then`
+   clause enforces. `helm install` with mode=external and an
+   empty DSN fails at lint time with a clear error message,
+   per the AGENTS.md substrate-plan pitfall. There is no
+   fall-back to the embedded host name; the embedded
+   StatefulSet is not even rendered when mode=external. See
+   §3.2.
+
+3. **No connection pooler in v0; document the threshold.** The
+   `task-store-server` is a single-replica Deployment that
+   opens one psycopg connection per process. There is no fan-in
+   problem to pool. A pooler (PgBouncer in transaction mode)
+   becomes load-bearing only when the chart starts running
+   `replicas.taskStoreServer > 1` (out of scope for 13c — the
+   wire layer's at-most-one-success-on-claim invariant relies
+   on store-side serialization, which a multi-replica server
+   doesn't provide today; that's a future amendment). The chart
+   ships NO pooler templates; the `eden.storeUrl` helper passes
+   the operator-supplied DSN through unchanged. The runbook
+   documents the threshold and points operators at PgBouncer +
+   their managed provider's pooling guidance for when they need
+   it. See §3.4.
+
+4. **Schema management stays `ensure_schema`-on-first-connect;
+   defer Alembic/sqitch to a future chunk.** The
+   `_postgres_schema.py` linear-migration mechanism is
+   idempotent and works identically against managed Postgres as
+   against the embedded one. Adding a migration tool now would
+   require: choosing the tool (Alembic vs sqitch vs hand-rolled),
+   restructuring the schema directory, wiring migrations into
+   the chart's lifecycle (pre-install Job? init container?),
+   gating the task-store-server's start on migration completion.
+   None of that buys 13c anything — there are no in-flight
+   migrations to coordinate; v0 has one schema version. The
+   future chunk that introduces the FIRST schema migration
+   (e.g., the jsonb-column conversion the existing
+   `_postgres_schema.py` docstring foreshadows) is the right
+   place to land migration tooling. See §3.5. **Note:** if a
+   future chunk drops `ensure_schema` in favor of operator-run
+   migrations, the swap is breaking for 13c-era deployments
+   that never ran the operator-side migration tool — the
+   migration tool's first release MUST include a "import the
+   ensure_schema-applied state" mode that recognizes the
+   `schema_version` table 13c writes (capture this now as a
+   load-bearing constraint on the future tool).
+
+5. **TLS posture: opt-in, with verify-full as the recommended
+   default for managed providers.** Most managed Postgres
+   providers (RDS, Cloud SQL, AlloyDB) require TLS and offer a
+   public CA bundle. The chart's `postgres.tls` block lets the
+   operator enable TLS verification, supply the provider's CA
+   via a Secret, and choose `sslmode ∈ {require, verify-ca,
+   verify-full}`. Default `tls.enabled=false` (preserves 13a
+   embedded mode's plaintext local-cluster behavior); when
+   `mode=external`, the runbook strongly recommends
+   `tls.enabled=true` + `tls.mode=verify-full`. Rejected:
+   forcing TLS on whenever `mode=external` (some operators run
+   managed Postgres on a private network where TLS is
+   redundant; making it mandatory creates friction for no
+   security benefit in those topologies). See §3.3.
+
+6. **Failover and read-replicas are out of scope.** Managed
+   providers offer their own failover mechanisms (RDS
+   Multi-AZ, Cloud SQL HA, AlloyDB regional clusters); they
+   either present a single writer endpoint that handles
+   failover transparently OR a separate read endpoint. The
+   chart's DSN is a single writer URL — that's all
+   `task-store-server` needs. Read-replicas would help only if
+   the chart ran multiple `task-store-server` replicas with
+   read-routing (out of scope per Decision 3). Documented as a
+   future amendment. See §3.6.
+
+7. **Backup is the operator's concern; EDEN documents what
+   needs to persist.** Managed providers ship their own backup
+   tooling (point-in-time-recovery, snapshots, cross-region
+   replicas). EDEN's contribution is documenting WHAT to back
+   up: every Postgres table the `_postgres_schema.py` migration
+   creates (`experiment`, `task`, `submission`, `idea`,
+   `variant`, `event`, `schema_version`). Plus 12b portable
+   checkpoints — but those are an EDEN-level export, not a
+   provider-level backup; documented separately. See §3.7.
+
+8. **Migration from embedded to external is a documented
+   `pg_dump`/`pg_restore` runbook, not scripted automation.**
+   The runbook covers: drain workers (or take the orchestrator
+   to zero replicas), snapshot the embedded StatefulSet via
+   `pg_dump --format=custom`, restore into the managed
+   instance, swap `postgres.mode=embedded` →
+   `postgres.mode=external` + supply the new DSN, run
+   `helm upgrade`, watch the rolling restart, verify the
+   `schema_version` table round-tripped, scale workers back
+   up. Plus a parallel "fresh deployment on external
+   Postgres" path that just sets the DSN at install time. See
+   §3.8. Rejected: a scripted migration tool — it would need
+   to know the operator's managed-provider auth shape (IAM,
+   passwords, Cloud SQL Auth Proxy, etc.) which varies per
+   provider and per operator. A runbook lets the operator
+   substitute their auth specifics; a script either becomes a
+   per-provider matrix or a least-common-denominator that
+   doesn't help anyone.
+
+9. **Coexistence with 13a is preserved by chart-default
+   embedded mode.** Operators on chart 0.1.0 (13a) upgrade to
+   chart 0.2.0 (13c) without changing `values.yaml`; the
+   default `postgres.mode=embedded` keeps the existing
+   `StatefulSet` exactly as 13a deployed it, and the new
+   `postgres.external.*` block sits empty. Existing PVCs
+   attach to the new StatefulSet without data loss (the PVC
+   name `<release>-eden-postgres-postgres-0` is unchanged
+   under the same `volumeClaimTemplates`). See §3.9.
+
+10. **CI: `helm-smoke-managed-postgres` job stands up
+    Postgres outside the kind cluster.** The CI smoke for
+    managed-Postgres mode runs `postgres:16.6-alpine` as a
+    sibling Docker container (NOT inside the kind cluster), then
+    installs the chart with `postgres.mode=external` and a DSN
+    pointing at the sibling. This proves the
+    `task-store-server`-pod-reaching-out-to-an-external-DSN path
+    works against a Postgres that isn't k8s-managed. Rejected:
+    using kind's own Postgres (defeats the purpose — that's
+    just the embedded smoke); using a real RDS instance in CI
+    (cost + secrets + flakiness from network egress to AWS).
+    See §3.10.
+
+## 3. Design
+
+### 3.1 `postgres.mode` switch
+
+#### 3.1.1 Values surface
+
+```yaml
+postgres:
+  # 13c adds this knob. Default mirrors 13a's hardcoded embedded path.
+  mode: "embedded"            # ∈ {embedded, external}
+
+  # 13a's existing fields move under this namespace. Operators on
+  # 13a's flat layout get a deprecation warning at template time
+  # (handled by a `tpl` lookup in _helpers.tpl that falls back to
+  # the legacy keys for one chart version). See §3.1.2.
+  embedded:
+    image:
+      repository: postgres
+      tag: 16.6-alpine
+      pullPolicy: IfNotPresent
+    storage:
+      className: ""           # cluster default if empty
+      size: 10Gi
+    # database/user/password come from secrets.postgresPassword
+    # (chart-managed Secret) or secrets.existingSecret (13a §3.3).
+
+  external:
+    # The libpq URL-form DSN. REQUIRED when mode=external (and no
+    # existingSecret). Format MUST be URL-style:
+    #   postgresql://[user[:pass]@]host[:port][/dbname][?param=value...]
+    # (or `postgres://...`). Libpq's alternate keyword form
+    # (`host=foo port=5432 dbname=eden user=eden ...`) is NOT
+    # accepted — the task-store-server dispatches store URLs by
+    # scheme prefix at
+    # [`reference/services/task-store-server/src/eden_task_store_server/app.py`](../../reference/services/task-store-server/src/eden_task_store_server/app.py)
+    # lines 37-57; a keyword DSN would be misread as a SQLite
+    # bare-path. The values.schema.json regex enforces the
+    # url-form prefix (§3.2.1).
+    # NOTE: do NOT inline this in a public values.yaml; prefer
+    # existingSecret for production. The chart accepts inline only
+    # for ergonomic dev use. Prefer to URI-encode special chars in
+    # passwords (mirrors setup-experiment.sh's existing posture at
+    # reference/scripts/setup-experiment/setup-experiment.sh:292).
+    connectionString: ""
+
+    # Reference an existing Secret instead of inline DSN.
+    # The Secret MUST contain a key (default "EDEN_STORE_URL") whose
+    # value is the libpq DSN. When set, connectionString is ignored.
+    existingSecret: ""
+    connectionStringKey: "EDEN_STORE_URL"
+
+  # TLS posture, used in BOTH modes (embedded mostly stays plaintext
+  # but operators MAY enable it; external should usually have it on).
+  tls:
+    enabled: false
+    # When enabled=true, sslmode ∈ {require, verify-ca, verify-full}.
+    # verify-full is the strongest and recommended default for
+    # managed providers that publish a public CA bundle. require
+    # encrypts but doesn't verify the CN; verify-ca verifies the CA
+    # chain but not the hostname; verify-full does both.
+    mode: "verify-full"
+    # Reference an existing Secret containing the CA bundle (PEM).
+    # Mounted at /etc/eden/postgres-ca/ca.crt in the
+    # task-store-server pod. The DSN gets sslrootcert=<path>
+    # appended by the eden.storeUrl helper.
+    caBundleSecret: ""
+    caBundleKey: "ca.crt"
+```
+
+#### 3.1.2 Migration from 13a's flat layout
+
+13a shipped flat `postgres.*` keys (no `embedded` namespace was
+needed when there was only one mode). 13c moves
+`postgres.image.*`, `postgres.storage.*` under
+`postgres.embedded.*`. To preserve chart-upgrade compatibility:
+
+- The `_helpers.tpl` `eden.postgres.image` and
+  `eden.postgres.storageSize` helpers prefer
+  `.Values.postgres.embedded.*` and fall back to the legacy
+  `.Values.postgres.*` keys when present.
+- A NOTES.txt warning at install time flags when legacy keys
+  are detected ("`.Values.postgres.image.repository` is
+  deprecated; use `.Values.postgres.embedded.image.repository`.
+  Will be removed in chart 0.3.0.").
+- The chart 0.3.0 release (a future 13-series chunk) drops the
+  fallback. 13c keeps it for one version.
+
+This is the only backward-compat shim the plan adds. Per the
+AGENTS.md project-lifecycle rule on greenfield projects, normally
+we'd just rename without a shim — but 13a is the FIRST chart
+release and operators may already have `values.yaml` files in
+their own repos targeting it. One version of fallback is
+proportionate; not maintaining it permanently is also right.
+
+#### 3.1.3 Conditional rendering
+
+Each Postgres-specific template wraps in:
+
+```yaml
+{{- if eq .Values.postgres.mode "embedded" -}}
+# ... existing 13a StatefulSet / Service ...
+{{- end }}
+```
+
+The `task-store-server` Deployment template stops hard-coding
+the embedded host name. Per §3.2.2, the
+`EDEN_STORE_URL` env var sources from a Secret as a single
+pre-composed URL string in all four sub-cases (embedded with
+chart-managed secrets; embedded with `existingSecret`;
+external with `connectionString`; external with
+`existingSecret`). The new `_helpers.tpl` helpers
+`eden.storeUrlSecretName` and `eden.storeUrlSecretKey` resolve
+to the right name/key per sub-case; the Pod spec wires those
+into a single `env: - name: EDEN_STORE_URL; valueFrom:
+secretKeyRef: {name: ..., key: ...}` entry.
+
+In all sub-cases, the rendered Pod spec uses `valueFrom:
+secretKeyRef:` so the DSN is never visible in `kubectl get pod
+-o yaml`'s spec section — only in the Secret it references.
+The other deployment credentials (`EDEN_SHARED_TOKEN`, etc.)
+keep using `envFrom: secretRef:` from 13a; only
+`EDEN_STORE_URL` switches to `valueFrom` (per §8.5's env-
+ordering note: with `valueFrom` we control resolution order
+explicitly, and we don't need `$(VAR)`-expansion across env
+entries).
+
+### 3.2 DSN handling and `values.schema.json` enforcement
+
+#### 3.2.1 Schema clauses
+
+```json
+{
+  "if": { "properties": { "postgres": { "properties": { "mode": { "const": "external" } } } } },
+  "then": {
+    "properties": {
+      "postgres": {
+        "properties": {
+          "external": {
+            "anyOf": [
+              {
+                "properties": {
+                  "connectionString": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^postgres(ql)?://"
+                  }
+                },
+                "required": ["connectionString"]
+              },
+              {
+                "properties": {
+                  "existingSecret":       { "type": "string", "minLength": 1 },
+                  "connectionStringKey":  { "type": "string", "minLength": 1 }
+                },
+                "required": ["existingSecret", "connectionStringKey"]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The `anyOf` clause permits EITHER an inline DSN OR an
+`existingSecret` reference; both being empty fails. Both being
+SET is permitted by the schema but `existingSecret` wins in
+`_helpers.tpl` (documented in the values comment).
+
+`helm install` with `postgres.mode=external` and neither knob
+set fails with a clear error — per the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+#### 3.2.2 DSN composition — Secret holds the full URL
+
+Both modes converge on the same Pod-spec shape: the
+`task-store-server`'s `EDEN_STORE_URL` env var sources from a
+Kubernetes Secret as a SINGLE pre-composed URL string. The
+chart never composes the DSN at template time from separate
+host/user/password fields — that posture would break under
+`secrets.existingSecret` (13a §3.3) where Helm doesn't see
+the password value at template time and therefore couldn't
+URI-encode it. Instead:
+
+- **Embedded mode, chart-managed secrets.** The chart's
+  `secret.yaml` template URL-composes the DSN at template
+  time using `printf "postgresql://eden:%s@%s-eden-postgres:5432/eden"
+  (urlquery .Values.secrets.postgresPassword) (include "eden.fullname" .)`
+  and writes the result into the chart-managed Secret as the
+  `EDEN_STORE_URL` key. `urlquery` runs against the literal
+  password value the chart owns. The TLS suffix (if any) is
+  appended in the same `printf` call.
+- **Embedded mode, `secrets.existingSecret`.** The operator's
+  pre-created Secret MUST contain `EDEN_STORE_URL`. **This is
+  a NEW contract introduced by 13c** — 13a's chart composed
+  the DSN at template time from `secrets.postgresPassword`,
+  so 13a operators using `existingSecret` did NOT need to
+  populate `EDEN_STORE_URL`. 13c shifts DSN composition into
+  the Secret value to avoid the urlquery-without-the-password
+  failure mode (§3.2.2 motivation), so 13a operators upgrading
+  to chart 0.2.0 with `secrets.existingSecret` set MUST add
+  the `EDEN_STORE_URL` key before the upgrade. See §8.3b for
+  the upgrade-trap details and the NOTES.txt warning the
+  chart emits. The chart itself does NOT compose anything;
+  it just references the operator-supplied key.
+- **External mode, `external.connectionString`.** The chart's
+  `secret.yaml` writes the operator-supplied DSN into the
+  chart-managed Secret as `EDEN_STORE_URL`. No reformatting,
+  no `urlquery` (the operator owns their password's encoding;
+  see §3.2.3). If `tls.enabled=true`, the `eden.tlsSuffix`
+  helper is appended at write time using the same
+  `?`-or-`&` discrimination logic.
+- **External mode, `external.existingSecret`.** The chart
+  references the operator-supplied Secret directly. The TLS
+  suffix CANNOT be appended at chart-template time (the chart
+  doesn't see the value). When `tls.enabled=true` AND
+  `external.existingSecret` is set, the operator MUST encode
+  the sslmode/sslrootcert in their pre-supplied DSN; the
+  chart's `values.schema.json` enforces that
+  `tls.enabled=false` is the only legal combination with
+  `external.existingSecret` UNLESS the operator confirms via
+  a separate value `external.tlsAlreadyEncodedInSecret: true`
+  (acknowledgement-style flag — sets a discriminator the
+  schema can require). This avoids silent mis-match where the
+  chart appends `?sslmode=...` after the operator already
+  encoded `?sslmode=disable` and produces `?sslmode=disable&sslmode=verify-full`.
+
+In all four cases, the rendered Pod's env block contains a
+single `EDEN_STORE_URL` entry sourced via
+`valueFrom: secretKeyRef:` (chart-managed or
+operator-supplied Secret per the case). `EDEN_STORE_URL` is
+then passed through to the `task-store-server` `--store-url`
+flag via `args: ["--store-url", "$(EDEN_STORE_URL)"]`. K8s
+expands the `$(VAR)` syntax in args; the secret value never
+appears in `spec.containers[0].args` literal text or in
+`kubectl get pod -o yaml`. (The
+[Kubernetes env expansion docs](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+specify that `$(VAR)` in `args` resolves against env vars
+defined for the container.)
+
+The `eden.storeUrl` helper, then, is NOT a runtime DSN
+composer — it's a template-time helper that picks the right
+SecretKeyRef (chart-managed name vs `existingSecret`) for the
+Pod spec to reference.
+
+#### 3.2.3 Password URI-encoding
+
+The compose `setup-experiment.sh` URI-encodes the password into
+the DSN ([`reference/scripts/setup-experiment/setup-experiment.sh`](../../reference/scripts/setup-experiment/setup-experiment.sh)
+line 292). The chart's embedded path mirrors that posture
+because user-supplied passwords may contain `@`, `:`, `/`, `?`,
+`#` reserved characters. Per §3.2.2, the chart's `secret.yaml`
+template runs `urlquery .Values.secrets.postgresPassword` at
+template time, before composing the embedded DSN. This applies
+ONLY to the embedded-mode + chart-managed-secrets case (where
+Helm sees the password value); for `secrets.existingSecret`
+the operator pre-encoded the value when they wrote the secret
+key.
+
+For external mode, the operator supplies the DSN directly
+(either inline in `connectionString` or pre-baked in
+`existingSecret`) and is responsible for their own password
+encoding — just like setup-experiment's CLI-password override
+path at line 292. The runbook + values comment flag this
+explicitly.
+
+The chart's `values.schema.json` partially validates external
+DSNs via the `^postgres(ql)?://` URL-prefix regex (§3.2.1). It
+does NOT fully parse the DSN; that's psycopg's job at
+connection time. A malformed DSN surfaces as a connection
+error in the task-store-server's startup logs, which is
+tolerable.
+
+### 3.3 TLS posture
+
+#### 3.3.1 The `postgres.tls` block
+
+Three knobs:
+
+- `tls.enabled: false`. When true, the chart appends
+  `?sslmode=...` (and possibly `&sslrootcert=...`) to
+  `EDEN_STORE_URL`.
+- `tls.mode: "verify-full"`. The libpq sslmode value;
+  `∈ {require, verify-ca, verify-full}` (the chart rejects
+  `disable`, `allow`, `prefer` — those modes are silently
+  weak and not appropriate for a managed-Postgres deployment).
+- `tls.caBundleSecret + tls.caBundleKey`. When `tls.mode ∈
+  {verify-ca, verify-full}`, the chart MUST mount a CA bundle.
+  `caBundleSecret` is the Secret name; `caBundleKey` is the
+  key within (default `ca.crt`).
+
+The `values.schema.json` enforces:
+
+- `tls.mode ∈ {require, verify-ca, verify-full}` (no
+  weaker modes).
+- When `tls.enabled=true` AND `tls.mode ∈ {verify-ca,
+  verify-full}`, `tls.caBundleSecret` MUST be non-empty.
+- When `tls.enabled=true` AND `postgres.mode=external` AND
+  `postgres.external.existingSecret` is set, the operator
+  MUST also set `postgres.external.tlsAlreadyEncodedInSecret:
+  true` to acknowledge that the chart cannot append the
+  sslmode/sslrootcert query suffix to a Secret it doesn't
+  read at template time (per §3.2.2). Otherwise the chart
+  would silently mis-match — appending `?sslmode=verify-full`
+  to a DSN whose operator already encoded a different mode.
+  When the flag is set, the chart skips its `eden.tlsSuffix`
+  injection and the operator's pre-baked DSN is the
+  authoritative source. The chart STILL mounts the CA bundle
+  Secret at the documented path so the operator's DSN can
+  reference it via `?sslrootcert=/etc/eden/postgres-ca/<key>`
+  if they choose.
+
+#### 3.3.2 CA bundle mounting
+
+The `task-store-server` Pod template gets a conditional
+`volumeMounts` entry plus a `volumes` entry referencing the
+Secret. Mount path is `/etc/eden/postgres-ca/`; file name is
+`{{ .Values.postgres.tls.caBundleKey }}` (typically `ca.crt`).
+The DSN suffix becomes:
+
+```text
+?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt
+```
+
+Helper: `eden.tlsSuffix` returns the empty string when
+`tls.enabled=false` and the appropriate suffix otherwise. The
+helper detects whether the DSN already contains a `?` (the
+operator may have encoded their own params) and emits `&` vs
+`?` accordingly.
+
+#### 3.3.3 Provider-specific CA bundle guidance
+
+The runbook documents how to obtain and load the CA bundle for
+the major providers:
+
+- **AWS RDS**: download `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+  load via `kubectl create secret generic eden-rds-ca
+  --from-file=ca.crt=global-bundle.pem`.
+- **GCP Cloud SQL**: download via the gcloud CLI; managed
+  Postgres on Cloud SQL exposes `sslmode=verify-ca` (the
+  server cert's CN is the instance ID, not a hostname, so
+  `verify-full` doesn't work without the Cloud SQL Auth
+  Proxy — see §3.3.4).
+- **Azure Postgres**: DigiCert Global Root CA / Microsoft RSA
+  Root CA (varies by region; documented in Azure docs).
+- **Supabase / Neon / Crunchy Bridge**: typically use Let's
+  Encrypt; the system trust bundle on most distros covers
+  them, but the chart still requires an explicit CA secret to
+  avoid relying on the `eden-runtime:dev` image's trust store
+  silently. The runbook walks through extracting the
+  appropriate root from the image's `ca-certificates` package.
+
+#### 3.3.4 The Cloud SQL Auth Proxy edge case
+
+GCP's Cloud SQL Auth Proxy presents the Postgres connection on
+a local UNIX socket or `127.0.0.1` port and handles TLS +
+authentication itself. Operators using the proxy connect to
+`postgresql:///cloudsql/<instance>?host=/cloudsql/<instance>`
+or `postgresql://eden:<pw>@127.0.0.1:5432/eden` with
+`sslmode=disable` because the proxy IS the secure transport.
+
+The chart MUST NOT force-enable `sslmode=verify-full` for
+external mode; the Cloud SQL Auth Proxy use case requires
+`tls.enabled=false` even though the data IS encrypted. The
+runbook covers this combination explicitly. The `values.yaml`
+default of `tls.enabled=false` accommodates the proxy case
+without operator intervention.
+
+Sidecar deployment of the Cloud SQL Auth Proxy (running it as
+a container in the `task-store-server` pod) is documented in
+the runbook but NOT shipped as a chart template — that's
+provider-specific and 13c's chart stays vendor-neutral.
+
+### 3.4 Connection management
+
+#### 3.4.1 Single-replica posture
+
+The `task-store-server` is a single-replica Deployment in 13a
+(Decision 5 in 13a §2: "Replica count is operator-configurable
+per service. Default for orchestrator is 2 (HA); for worker
+hosts it's 1"). The `task-store-server`'s default is also 1.
+With one replica, one psycopg connection per process, and a
+process-internal `RLock`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 153), Postgres sees at most ONE concurrent transaction
+per chart release.
+
+Managed Postgres providers offer connection limits typically
+in the hundreds (RDS free tier: 87; standard small instances:
+~100-200; Cloud SQL: 100 by default, configurable). One
+connection is well below any provider's limit.
+
+#### 3.4.2 The pooler threshold
+
+A pooler (PgBouncer in transaction-pooling mode) becomes
+load-bearing when:
+
+- The chart starts running `replicas.taskStoreServer > 1`
+  (out of scope for 13c — see Decision 3 in this plan; also
+  out of scope for the 13-series in general per AGENTS.md's
+  current state).
+- OR another EDEN service starts holding its own PostgresStore
+  connection (none today; the wire surface is the only path
+  to the Store).
+- OR the deployment runs many short-lived processes that each
+  open a connection (not the EDEN shape).
+
+13c does not ship a pooler. The runbook and the chart's
+`values.yaml` comments both flag the threshold. The
+`postgres.external.connectionString` already supports any DSN
+shape, so when an operator wants PgBouncer in front of their
+managed Postgres, they point the DSN at the pooler instead of
+the upstream — no chart change needed.
+
+#### 3.4.3 Connection lifecycle
+
+`PostgresStore` opens its connection in `__init__` and reuses
+it for the process lifetime. On a Postgres restart (e.g.,
+managed-provider maintenance window), the connection breaks;
+the next operation raises a psycopg `OperationalError`, which
+propagates as a 500 from the wire layer. The
+`task-store-server` Deployment's standard k8s health probe
+(13a `tests/test-connection.yaml`) catches a sustained
+connection failure and restarts the pod; on restart, the
+PostgresStore reconnects.
+
+This is the same lifecycle as embedded Postgres (the embedded
+StatefulSet can also restart). 13c does not add a connection-
+pool reconnect-on-error wrapper; the existing
+restart-on-health-check-failure behavior is sufficient and
+matches Compose.
+
+A future amendment MAY add psycopg connection-pool semantics
+(`psycopg_pool.ConnectionPool`) for resilience to transient
+network blips. 13c keeps the current single-connection posture
+to avoid scope creep — the pool would touch
+`PostgresStore.__init__` and the `_atomic_operation` context
+manager, both of which are tightly scoped today.
+
+### 3.5 Schema management
+
+#### 3.5.1 `ensure_schema` stays canonical
+
+`_postgres_schema.py`'s `ensure_schema(conn)` is idempotent:
+on first connection it creates `schema_version`, applies
+pending migrations from `_MIGRATIONS`, records the version. On
+re-connection it sees the version up-to-date and returns. The
+embedded and external paths run the same code at the same
+trigger point — `PostgresStore.__init__` calls
+`_postgres_schema.ensure_schema(self._conn)`
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 155).
+
+For managed Postgres, this means: the operator creates an
+empty database (per their provider's account-bootstrap
+mechanism), supplies the DSN, and the
+task-store-server bootstraps the schema on first start.
+There's no "run migrations before the chart" step — the
+chart's task-store-server pod IS the migration runner.
+
+This works because v0 has exactly ONE schema version
+(`_apply_v1`). Concurrent first-time bootstrap is impossible
+(single replica). Re-bootstrap is a no-op.
+
+#### 3.5.2 When this approach breaks
+
+`ensure_schema`-on-first-connect breaks when:
+
+- Multiple replicas start simultaneously and race on
+  `CREATE TABLE` (only one replica today, but a future
+  multi-replica server would need a transactional advisory
+  lock around the migration block — that's a small change
+  to `_postgres_schema.py`).
+- A schema migration is non-trivial (e.g., requires an
+  operator-driven data migration before the new version goes
+  live). The first such migration is the trigger to introduce
+  Alembic/sqitch and split migration from server-startup.
+  None of that is in 13c.
+- An operator wants to run the schema upgrade against a
+  staging database before promoting to prod. Today they
+  can't — the server applies migrations on first connect
+  unconditionally. A future migration tool would offer a
+  `migrate up --dry-run` mode for staging gates.
+
+#### 3.5.3 What 13c documents
+
+The runbook documents:
+
+- The schema bootstrap is automatic on `task-store-server`
+  startup; no operator action is required for an empty
+  managed-Postgres database.
+- Migrating from embedded to external: pg_dump captures the
+  `schema_version` table along with everything else. After
+  pg_restore, the next `task-store-server` start sees the
+  version up-to-date and skips re-bootstrap. There's no
+  separate "run migrations on the new database" step.
+- Future schema changes will move to an explicit migration
+  tool; operators are NOT promised a stable
+  `_postgres_schema.py`-driven flow long-term.
+
+### 3.6 Failover and read-replicas
+
+13c supports single-writer DSNs only. Managed providers'
+multi-AZ / regional-failover offerings present a single endpoint
+that handles failover transparently; the chart's DSN points at
+that endpoint and benefits automatically. No chart changes
+needed.
+
+Read-replicas are out of scope. EDEN's `Store.subscribe` (chapter
+8 §2.1) and `read_range` queries could in principle route to a
+replica, but the current `PostgresStore` doesn't distinguish
+read from write paths and the wire layer doesn't carry that
+intent. A future amendment that adds read-routing would touch
+`PostgresStore`, the wire surface, and the chart's DSN handling
+together — that's a multi-chunk effort, not 13c's scope.
+
+The runbook flags read-replica deployments as a "future
+amendment" and explicitly states the chart does not currently
+support them. Operators with very-read-heavy deployments are
+told that EDEN's protocol-level workload isn't read-bound today
+(every read is per-event-loop-iteration, not bulk).
+
+### 3.7 Backup and DR
+
+#### 3.7.1 What needs to persist
+
+The Postgres tables that hold protocol state, per
+`_postgres_schema.py` `_V1_STATEMENTS`:
+
+- `experiment` — experiment ID + frozen evaluation_schema.
+- `task` — task lifecycle state.
+- `submission` — per-task submission payload.
+- `idea` — idea lifecycle state.
+- `variant` — variant lifecycle state.
+- `event` — append-only event log; chapter 8 §3 requires this
+  to survive across restarts.
+- `schema_version` — bootstrap migration state.
+
+A backup that captures all seven tables can fully restore an
+EDEN deployment (modulo Gitea, which has its own backup story
+in 13e).
+
+#### 3.7.2 Provider-side backup
+
+Managed providers offer:
+
+- Point-in-time recovery (PITR) via continuous WAL archiving.
+  Recovery to any second within the retention window.
+- Daily snapshots (RDS, Cloud SQL automated backups).
+- Cross-region replication (RDS Read Replicas, Cloud SQL
+  cross-region replicas).
+
+EDEN does not orchestrate any of these. The runbook documents
+which provider mechanism best fits a deployment's RPO / RTO
+goals (e.g., "PITR is the standard answer for production EDEN
+deployments; the protocol's append-only event log is fully
+recoverable to any commit point").
+
+#### 3.7.3 Application-level backup (12b portable checkpoints)
+
+Phase 12b's portable checkpoints are an EDEN-LEVEL export of
+the experiment state — a tarball containing the event log + all
+artifact references that an operator can carry between
+deployments. This is a SEPARATE concern from
+provider-Postgres-level backup:
+
+- 12b checkpoints are **forwards-portable**: import into a
+  fresh EDEN deployment (different cluster, different
+  Postgres, different managed provider).
+- Provider backups are **point-in-time-recoverable** to the
+  same managed instance.
+
+The runbook clarifies that 12b is the right answer for
+"export this experiment to share with another team" or "move
+this deployment to a different cloud"; provider backups are
+the right answer for "the database got corrupted, restore to
+yesterday afternoon".
+
+#### 3.7.4 What 13c ships
+
+Documentation only. No backup scripts, no scheduled-backup
+chart resources. The runbook covers the topology + provider
+options + the 12b interaction.
+
+### 3.8 Migration runbook
+
+The runbook at `docs/deployment/migrating-to-managed-postgres.md`
+covers two paths:
+
+#### 3.8.1 Path A: fresh deployment on managed Postgres
+
+Operator-side prerequisites: a managed Postgres instance, an
+empty database, a user account with `CREATE TABLE` /
+`CREATE INDEX` privilege on it. Walk-through:
+
+1. Create the empty database via the provider's console / CLI.
+2. Capture the connection string; URI-encode any special
+   chars in the password.
+3. Create a Kubernetes Secret with the DSN:
+
+   ```bash
+   kubectl create secret generic eden-managed-postgres \
+     --from-literal=EDEN_STORE_URL='postgresql://...'
+   ```
+
+4. Set chart values:
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+     tls:
+       enabled: true
+       mode: verify-full
+       caBundleSecret: eden-rds-ca   # or your provider's
+   ```
+
+5. `helm install eden ./reference/helm/eden -f values.yaml`.
+6. The `task-store-server` pod's first start runs
+   `ensure_schema`, creating all seven tables on the managed
+   instance. No further operator action.
+7. Run `setup-experiment-helm.sh` per 13a §3.5 to bootstrap
+   the first experiment.
+
+#### 3.8.2 Path B: migrating an existing 13a deployment
+
+Operator-side prerequisites: an EDEN release running with
+`postgres.mode=embedded` (13a default), a managed Postgres
+instance with an empty target database, network reachability
+between the operator's workstation and BOTH endpoints. The
+runbook step-by-step:
+
+1. **Drain workers.** Sequencing matters because the worker
+   hosts (executor / evaluator / ideator) claim tasks WITHOUT
+   an `expires_at` deadline (verified at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+   lines 123, 201;
+   [`reference/services/executor/src/eden_executor_host/subprocess_mode.py`](../../reference/services/executor/src/eden_executor_host/subprocess_mode.py)
+   line 164 + sibling files), so the orchestrator's
+   `sweep_expired_claims` at
+   [`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+   lines 32-67 SKIPS them — only the Web UI's claim path
+   (which carries a TTL per
+   [`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+   line 58) is affected by the sweeper. So the drain is
+   **operator-driven**, not TTL-based. The pattern is:
+   scale workers to 0 (graceful SIGTERM lets each worker
+   finish its in-flight task and submit, transitioning
+   `claimed` → `submitted` for the work that completed
+   within `terminationGracePeriodSeconds`), then operator-
+   reclaim any tasks that didn't finish.
+
+   Per 13a Decision 3, `executor-host` / `evaluator-host` /
+   `web-ui` are StatefulSets and `ideator-host` is a
+   Deployment:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=0
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=0
+   ```
+
+   Wait for the StatefulSet / Deployment to report 0 ready
+   replicas (`kubectl rollout status` or polling
+   `kubectl get`). Workers have up to
+   `terminationGracePeriodSeconds` (default 30s) to finish
+   their in-flight task on SIGTERM; any task that did finish
+   transitions to `submitted` via the existing submit path.
+
+   Then operator-reclaim any tasks still in `state=claimed`.
+   Two equivalent paths:
+
+   - **Web-UI admin route** (preferred when operators have
+     UI access): the 9e admin module's per-task detail page
+     exposes a "reclaim" / "force-reclaim (replays work)"
+     button per
+     [`reference/services/web-ui/src/eden_web_ui/routes/admin.py`](../../reference/services/web-ui/src/eden_web_ui/routes/admin.py)
+     (the `Store.reclaim(task_id, "operator")` path per
+     [`spec/v0/04-task-protocol.md`](../../spec/v0/04-task-protocol.md)
+     §5.1). The runbook walks the operator through it
+     task-by-task. The Web UI is still scaled up at this
+     point (scale it to 0 in step 1's third sub-phase).
+   - **Direct API** (for headless operators or when the
+     Web UI is already down): `curl` against the
+     task-store-server's `reclaim` endpoint with the admin
+     bearer:
+
+     ```bash
+     # Note: $EID is the chart's --experiment-id (per
+     # setup-experiment-helm.sh / chart values). The actual wire
+     # endpoints live at /v0/experiments/{experiment_id}/... — see
+     # reference/packages/eden-wire/src/eden_wire/server.py line 183
+     # for the base. The reclaim body is a POST JSON body
+     # ({"cause": "operator"}), not a query param.
+     for tid in $(kubectl exec -n eden-prod \
+       deployment/eden-task-store-server -- \
+       curl -s -H "Authorization: Bearer $TOKEN" \
+       "http://localhost:8080/v0/experiments/$EID/tasks?state=claimed" \
+       | jq -r '.[].task_id'); do
+       kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+         curl -X POST -H "Authorization: Bearer $TOKEN" \
+         -H "Content-Type: application/json" \
+         -d '{"cause": "operator"}' \
+         "http://localhost:8080/v0/experiments/$EID/tasks/$tid/reclaim"
+     done
+     ```
+
+   Confirm `state=claimed` is empty via the wire
+   `/admin/tasks/` endpoint or
+   `curl ...?state=claimed | jq length`. Then scale the
+   orchestrator to zero, and the web-ui:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator eden-web-ui --replicas=0
+   ```
+
+   The `task-store-server` keeps running so we can read its
+   state for the final consistency check before snapshotting.
+
+   Note that an alternative shape — leaving workers running
+   and capturing `pg_dump` against an active state — is NOT
+   safe: `pg_dump --format=custom` produces an internally
+   consistent snapshot of the SQL state but the Gitea-side
+   git refs the workers may push during the dump are NOT
+   captured, breaking the chapter-6 §3.4 atomicity invariant
+   on restore. The drain is mandatory.
+
+2. **Capture pre-snapshot baselines, then `pg_dump`.** Before
+   `pg_dump` runs, record the event count and the highest event
+   seq from the embedded Postgres. Step 4's SQL verification
+   and step 7's wire-endpoint verification both compare against
+   these baselines. The `task-store-server` is still running at
+   this point.
+
+   ```bash
+   # SQL-side baseline (queried directly against the embedded pod):
+   EVENT_COUNT_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
+     psql --user=eden --dbname=eden -tAc 'SELECT count(*) FROM event;')
+   MAX_SEQ_BEFORE=$(kubectl exec -n eden-prod eden-postgres-0 -- \
+     psql --user=eden --dbname=eden -tAc 'SELECT COALESCE(MAX(seq), 0) FROM event;')
+   echo "baseline: events=$EVENT_COUNT_BEFORE max_seq=$MAX_SEQ_BEFORE"
+
+   # Wire-side baseline (cursor walk; same shape as step 7's
+   # post-migration check). Captures the same count via the
+   # public surface so the post-migration verification can be
+   # apples-to-apples even if the operator can't shell into
+   # the new Postgres directly.
+   WIRE_COUNT_BEFORE=$(kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "$count"')
+   echo "wire-baseline events: $WIRE_COUNT_BEFORE"
+   ```
+
+   Save these three numbers. (Wire-side count and SQL-side
+   count SHOULD match for a quiesced experiment; if they
+   diverge, investigate before snapshotting — likely indicates
+   an in-flight write that the step-1 drain didn't catch.)
+
+   Then run `pg_dump`:
+
+   ```bash
+   kubectl exec -n eden-prod eden-postgres-0 -- \
+     pg_dump --format=custom --no-owner --no-acl \
+       --user=eden --dbname=eden \
+     > eden-snapshot.dump
+   ```
+
+   `--no-owner --no-acl` strips the embedded `eden` role
+   ownership; the managed instance has its own role
+   (typically not named `eden`). `--format=custom` is
+   `pg_restore`-compatible.
+
+3. **Restore into managed Postgres.** Using a workstation
+   with `pg_restore` and credentials for the managed instance:
+
+   ```bash
+   pg_restore --no-owner --no-acl --dbname='postgresql://...' \
+     eden-snapshot.dump
+   ```
+
+   On managed providers that disallow `CREATE DATABASE` from
+   non-superusers, ensure the database exists first.
+
+4. **Verify the schema_version round-trip.** Connect to the
+   managed instance and confirm against the baselines captured
+   in step 2:
+
+   ```sql
+   SELECT MAX(version) FROM schema_version;
+   -- expects 1
+   SELECT count(*) FROM event;
+   -- expects EVENT_COUNT_BEFORE
+   SELECT COALESCE(MAX(seq), 0) FROM event;
+   -- expects MAX_SEQ_BEFORE
+   ```
+
+5. **Swap the chart values.** Edit `values.yaml` to set
+   `postgres.mode=external` and supply
+   `postgres.external.existingSecret` (or
+   `connectionString`):
+
+   ```yaml
+   postgres:
+     mode: external
+     external:
+       existingSecret: eden-managed-postgres
+   ```
+
+6. **Helm upgrade.**
+
+   ```bash
+   helm upgrade eden ./reference/helm/eden -f values.yaml \
+     -n eden-prod --wait
+   ```
+
+   The chart removes the `eden-postgres` StatefulSet (the
+   PVC stays — k8s does NOT delete StatefulSet PVCs on scale-
+   to-zero; the operator can `kubectl delete pvc eden-postgres-...`
+   manually as a final step). The `task-store-server` Deployment
+   gets re-rolled with the new env var; on restart it points
+   at the managed DSN. `ensure_schema` sees `schema_version`
+   already populated and is a no-op.
+
+7. **Post-migration verification.** Hit the wire endpoint
+   directly. Endpoint shapes per
+   [`reference/packages/eden-wire/src/eden_wire/server.py`](../../reference/packages/eden-wire/src/eden_wire/server.py)
+   lines 183-508 (and the `/healthz` endpoint added in 9e).
+   The `/v0/experiments/{E}/events` endpoint paginates via a
+   `cursor` query param (not `limit`); to confirm event-count
+   parity with the pre-snapshot state, walk the cursor or
+   simply count the response on a fresh deployment where it
+   fits in one page.
+
+   ```bash
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s http://localhost:8080/healthz
+   # Walk the events cursor to count total events. Compare
+   # the result against the wire-side baseline captured in
+   # step 2 (the "wire-baseline events:" line).
+   # cursor=0 returns the first batch; the response includes a
+   # forward `cursor` to feed the next call.
+   #
+   # Both $TOKEN and $EID are operator-side env vars; pass them
+   # explicitly via `env` to the kubectl-exec'd shell so the
+   # double-quoted bash -c string sees the right values. (A
+   # single-quoted bash -c body would not expand $TOKEN at all;
+   # a double-quoted body with no `env` would expand $TOKEN on
+   # the operator side, which is what we want — but using `env`
+   # makes the boundary explicit.)
+   kubectl exec -n eden-prod deployment/eden-task-store-server \
+     -- env "TOKEN=${TOKEN}" "EID=${EID}" bash -c '
+       count=0; cursor=0;
+       while :; do
+         resp=$(curl -s -H "Authorization: Bearer $TOKEN" \
+           "http://localhost:8080/v0/experiments/$EID/events?cursor=$cursor")
+         batch=$(echo "$resp" | jq ".events | length")
+         count=$((count + batch))
+         next=$(echo "$resp" | jq ".cursor")
+         [ "$batch" = "0" ] && break
+         [ "$next" = "$cursor" ] && break
+         cursor=$next
+       done
+       echo "events: $count"'
+   # Variants in success status (sanity-check a non-zero count
+   # for any non-trivial experiment). Operator-side $TOKEN and
+   # $EID expansion (no `env` passthrough needed — single curl
+   # call resolved by the outer shell):
+   kubectl exec -n eden-prod deployment/eden-task-store-server -- \
+     curl -s -H "Authorization: Bearer ${TOKEN}" \
+       "http://localhost:8080/v0/experiments/${EID}/variants?status=success" \
+     | jq length
+   ```
+
+8. **Scale workers back up.** Reverse-order from step 1: bring
+   the orchestrator up first so its sweeper is running before
+   workers start claiming, then bring the workers back. The
+   ideator-host is a Deployment per 13a Decision 3; the rest
+   are StatefulSets:
+
+   ```bash
+   kubectl scale statefulset -n eden-prod \
+     eden-orchestrator --replicas=2
+   kubectl scale statefulset -n eden-prod \
+     eden-executor-host eden-evaluator-host \
+     --replicas=1
+   kubectl scale deployment -n eden-prod \
+     eden-ideator-host \
+     --replicas=1
+   ```
+
+   Workers re-acquire leases on the live experiment(s) within
+   one poll-interval.
+
+9. **Decommission embedded PVC.** Once the deployment is
+   stable on managed Postgres for at least one experiment
+   cycle:
+
+   ```bash
+   kubectl delete pvc -n eden-prod eden-postgres-eden-postgres-0
+   ```
+
+   This frees the underlying storage. Skip this step until
+   you're confident in the migration; the PVC is the only
+   rollback path back to the embedded store.
+
+10. **Rollback (if needed).** If post-migration verification
+    fails AND you haven't deleted the embedded PVC: revert
+    `values.yaml` to `postgres.mode=embedded`, re-run
+    `helm upgrade`. The StatefulSet comes back, attaches to
+    the surviving PVC, and the embedded store is live again.
+    Any data written to the managed instance during the
+    failed cutover is lost (no double-write).
+
+#### 3.8.3 Why a runbook, not a script
+
+A scripted migration would need to know:
+
+- The operator's managed-provider auth (IAM role, password,
+  Cloud SQL Auth Proxy, etc.). Each provider has its own
+  shape.
+- The operator's network topology (is the managed instance
+  reachable from the cluster? from the workstation? both?).
+- The operator's risk tolerance for downtime (some operators
+  want a one-shot cutover; others want a parallel-run period
+  with ad-hoc dual-write reconciliation that EDEN can't do
+  protocol-side anyway).
+
+A runbook lets the operator substitute their specifics; a
+script becomes a per-provider matrix or a least-common-
+denominator. Per AGENTS.md substrate-plan pitfall on
+multi-tenant lifecycle: per-experiment / per-cluster
+artifacts belong outside the chart, owned by setup scripts.
+Migration is a per-deployment artifact; it goes in the
+runbook.
+
+### 3.9 Coexistence with 13a
+
+Chart 0.2.0 (13c) on top of an unmodified 13a `values.yaml`:
+
+- `postgres.mode` defaults to `embedded` — 13a behavior
+  preserved exactly.
+- Legacy flat `postgres.image.*` / `postgres.storage.*` keys
+  fall through the `_helpers.tpl` lookup (§3.1.2). Operators
+  see a NOTES.txt deprecation warning but no install failure.
+- The embedded `StatefulSet`'s name and PVC name are
+  unchanged across 13a → 13c, so the existing PVC reattaches
+  without data loss.
+
+Chart 0.3.0 (a future chunk) drops the legacy-key fallback;
+operators must have migrated their `values.yaml` to the
+namespaced form by then. The runbook flags this for 13c
+operators who customize `postgres.*`.
+
+### 3.10 CI: `helm-smoke-managed-postgres`
+
+A new CI job mirrors 13a's `helm-smoke` but uses
+`postgres.mode=external` against an out-of-cluster Postgres:
+
+```yaml
+helm-smoke-managed-postgres:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: helm/kind-action@v1.10
+    - uses: azure/setup-helm@v3
+    - name: Start sibling Postgres
+      run: |
+        docker run -d --name eden-ci-pg \
+          --network kind \
+          -e POSTGRES_USER=eden \
+          -e POSTGRES_PASSWORD=ci-test-password \
+          -e POSTGRES_DB=eden \
+          postgres:16.6-alpine
+        # Wait for ready
+        for i in $(seq 1 30); do
+          docker exec eden-ci-pg pg_isready -U eden -d eden && break
+          sleep 1
+        done
+        # Capture the sibling container's IP on the kind network — kind's
+        # CoreDNS does NOT resolve sibling-container names by default
+        # (per §8.6), so the DSN must reference the IP directly. Stash
+        # the IP in $GITHUB_ENV so later steps see it.
+        PG_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' eden-ci-pg)
+        echo "EDEN_CI_PG_IP=${PG_IP}" >> "$GITHUB_ENV"
+    - name: Build + load chart's image into kind
+      run: |
+        docker build -t eden-reference:dev \
+          -f reference/compose/Dockerfile .
+        kind load docker-image eden-reference:dev
+    - name: Helm install with mode=external
+      run: |
+        kubectl create namespace eden-test
+        # Use the sibling Postgres' IP (captured above), NOT
+        # `eden-ci-pg`. CoreDNS in kind resolves only Service DNS
+        # for in-cluster Services; a host on the kind Docker network
+        # is reachable by IP but not by docker container name from
+        # inside pods. See §8.6.
+        kubectl create secret generic eden-managed-pg \
+          -n eden-test \
+          --from-literal=EDEN_STORE_URL="postgresql://eden:ci-test-password@${EDEN_CI_PG_IP}:5432/eden"
+        helm install eden ./reference/helm/eden \
+          -f reference/helm/eden/ci-values-managed-postgres.yaml \
+          -n eden-test --wait --timeout 5m
+    - name: Run setup-experiment + assert end-state
+      run: |
+        bash reference/scripts/setup-experiment-helm.sh \
+          --namespace eden-test \
+          --experiment-config tests/fixtures/experiment/.eden/config.yaml \
+          --experiment-id exp-1
+        # Same end-state assertions as helm-smoke (13a §3.6).
+        # ... poll wire endpoint until quiescence ...
+        # ... assert ≥3 variant.integrated, ≥9 task.completed ...
+    - name: Cleanup
+      if: always()
+      run: |
+        helm uninstall eden -n eden-test || true
+        kind delete cluster
+        docker rm -f eden-ci-pg || true
+```
+
+The `kind` cluster's network is `kind` (Docker network created
+by kind-action); a sibling container on the same network is
+reachable from kind pods at the container's IP on that network
+(captured into `${EDEN_CI_PG_IP}` above). The kind cluster's
+CoreDNS does NOT resolve sibling-container names — see §8.6 —
+so the DSN MUST embed the IP, not `eden-ci-pg`. The IP-based
+path bypasses the kind-cluster Service abstraction and proves
+the external-DSN path works against a Postgres the chart did
+NOT create.
+
+`ci-values-managed-postgres.yaml` (new) sets:
+
+```yaml
+postgres:
+  mode: external
+  external:
+    existingSecret: eden-managed-pg
+  tls:
+    enabled: false   # CI uses plaintext; the TLS path is exercised by unit-equivalent helm template assertions
+```
+
+Per AGENTS.md "narrow CI subsets aren't substitutes" — the
+job runs the same end-state invariant assertions as
+`helm-smoke` so the wire-level outcome is identical across
+both deployment modes. Per the same pitfall, this CI job
+does NOT replace the existing `helm-smoke` (which still tests
+the embedded path); 13c CI runs BOTH.
+
+Branch protection is **not** updated to require
+`helm-smoke-managed-postgres` in 13c (same posture 13a /
+13b took for newly-added CI jobs — let it run clean for a
+few rounds before gating).
+
+### 3.11 Conformance impact
+
+13c does not change the wire surface, the protocol, or any
+spec text. The conformance suite is binding-agnostic per
+chapter 9 §6 (the chapter-7 HTTP binding is the only IUT
+contract); a deployment running on managed Postgres passes
+the same scenarios as a deployment running on the embedded
+StatefulSet. No new conformance scenarios are added in 13c.
+
+The `helm-smoke-managed-postgres` CI job is the
+substrate-level proof; it asserts the same end-state
+invariants the existing smokes do.
+
+## 4. Scope
+
+### 4.1 In scope
+
+Chart additions:
+
+- `reference/helm/eden/values.yaml`: add `postgres.mode`,
+  rename existing flat `postgres.*` keys under
+  `postgres.embedded.*` (with backward-compat fallback per
+  §3.1.2), add `postgres.external.*`, add `postgres.tls.*`.
+- `reference/helm/eden/values.schema.json`: add `if/then`
+  clauses per §3.2.1 + TLS clauses per §3.3.1.
+- `reference/helm/eden/templates/_helpers.tpl`: add
+  `eden.storeUrl`, `eden.tlsSuffix`, and update existing
+  `eden.postgres.image` / `eden.postgres.storageSize` helpers
+  to do the namespaced lookup with legacy fallback.
+- `reference/helm/eden/templates/postgres-statefulset.yaml`:
+  wrap entire body in
+  `{{- if eq .Values.postgres.mode "embedded" -}}`.
+- `reference/helm/eden/templates/postgres-service.yaml`:
+  same conditional.
+- `reference/helm/eden/templates/task-store-server-deployment.yaml`:
+  switch from hard-coded embedded host to `eden.storeUrl`
+  helper output; add conditional CA bundle volume +
+  volumeMount when `postgres.tls.enabled=true`.
+- `reference/helm/eden/templates/secret.yaml`: when
+  `postgres.mode=external` AND
+  `postgres.external.connectionString` is non-empty (no
+  `existingSecret`), add the inline DSN to the chart-managed
+  Secret as `EDEN_STORE_URL`. When
+  `postgres.external.existingSecret` is set, the Secret
+  template skips this key.
+- `reference/helm/eden/templates/NOTES.txt`: add
+  legacy-key-deprecation warning per §3.1.2.
+
+CI:
+
+- `.github/workflows/ci.yml`: add
+  `helm-smoke-managed-postgres` job per §3.10.
+- `reference/helm/eden/ci-values-managed-postgres.yaml` (new).
+
+Docs:
+
+- `docs/deployment/migrating-to-managed-postgres.md` (new):
+  the runbook per §3.8.
+- `docs/deployment/helm.md` (extend the 13a doc): document
+  `postgres.mode`, the `external` configuration shape, the
+  TLS posture, and the connection-pooler threshold.
+- `AGENTS.md` Commands table: no new commands (the existing
+  `helm install` + `setup-experiment-helm.sh` flow covers
+  both modes).
+- `docs/roadmap.md` Phase 13 entry: mark 13c complete; cross-
+  link to this plan.
+
+### 4.2 Cross-references to followups
+
+- **S3/GCS blob backend** — 13d. Independent of Postgres
+  storage; touches the artifacts PVC.
+- **Gitea auth + per-branch ACLs + native PR review** —
+  13e. Independent of Postgres storage; touches Gitea.
+- **Multi-replica `task-store-server` + connection pooler** —
+  future amendment. Becomes load-bearing when chart adds HA
+  for the wire layer; out of scope for the 13-series.
+- **Alembic / sqitch migration tool** — future amendment.
+  Trigger is the FIRST non-trivial schema migration (e.g.,
+  the `_postgres_schema.py` docstring's foreshadowed
+  `text` → `jsonb` conversion).
+- **Read-replica routing for `Store.subscribe` /
+  `read_range`** — future amendment; depends on a
+  multi-replica server.
+
+### 4.3 Out of scope
+
+- **Bundled migration tool.** §3.5; deferred to first
+  non-trivial migration.
+- **Connection pooler (PgBouncer / pgcat / etc.).** §3.4;
+  not needed at single-replica scale.
+- **Provider-specific IaC (Terraform modules, Cloud SQL
+  Operator manifests, RDS CloudFormation).** Per-deployment
+  concern. EDEN's chart consumes the provider's output (a
+  DSN); provisioning the provider is upstream of EDEN.
+- **Backup / restore scripts.** §3.7; provider mechanisms +
+  the 12b portable-checkpoints export already cover this.
+- **Multi-region replication.** §3.6; future amendment.
+- **Failover testing.** Provider's responsibility; EDEN's
+  health probe handles connection drops at the pod level.
+
+### 4.4 Non-goals
+
+- **Backwards compat at the data level with a hand-managed
+  Postgres outside the chart.** If an operator runs Postgres
+  themselves (k3s + Postgres pod they manage manually) and
+  wants to switch to chart-managed embedded, the migration
+  story is the same `pg_dump`/`pg_restore` runbook in §3.8 —
+  no special script.
+- **Chart-managed RBAC for cloud SQL roles.** EDEN does not
+  configure `CREATE USER`, `GRANT`, or other DCL on the
+  managed instance. The runbook documents what privileges
+  the EDEN account needs (CREATE TABLE, CREATE INDEX, INSERT,
+  UPDATE, DELETE, SELECT, plus DDL for `ensure_schema`).
+- **Strict resource requests/limits on `task-store-server`
+  for the external mode.** The 13a defaults still apply.
+
+## 5. Files to touch
+
+### 5.1 Chart additions
+
+| File | Change |
+|---|---|
+| `reference/helm/eden/values.yaml` | Add `postgres.mode` (default `embedded`); move `postgres.image.*` / `postgres.storage.*` under `postgres.embedded.*` (with §3.1.2 fallback); add `postgres.external.*` block (`connectionString`, `existingSecret`, `connectionStringKey`, `tlsAlreadyEncodedInSecret`); add `postgres.tls.*` block (`enabled`, `mode`, `caBundleSecret`, `caBundleKey`). Comment-document the `existingSecret` recommended posture and the URL-form DSN constraint. |
+| `reference/helm/eden/values.schema.json` | Add `postgres.mode` enum; add `if/then` requiring non-empty `connectionString` (matching `^postgres(ql)?://`) OR `existingSecret + connectionStringKey` when mode=external; add `tls.mode ∈ {require, verify-ca, verify-full}` enum + the `caBundleSecret` requirement when mode ∈ {verify-ca, verify-full}; add the `tlsAlreadyEncodedInSecret: true` requirement when both `tls.enabled=true` and `external.existingSecret` are set. |
+| `reference/helm/eden/templates/_helpers.tpl` | Add `eden.storeUrlSecretName` (returns chart-managed name OR `secrets.existingSecret` OR `external.existingSecret` per mode + sub-case); add `eden.storeUrlSecretKey` (returns the literal `EDEN_STORE_URL` for chart-managed paths OR `external.connectionStringKey` for external+existingSecret); add `eden.embeddedDsn` (the embedded-mode template-time DSN composer using `urlquery` on the password and the optional TLS suffix); add `eden.tlsSuffix` (renders `?sslmode=...&sslrootcert=...` with `?`-vs-`&` discrimination); update `eden.postgres.image` / `eden.postgres.storageSize` to use embedded namespace with legacy fallback. |
+| `reference/helm/eden/templates/postgres-statefulset.yaml` | Wrap entire body in `{{- if eq .Values.postgres.mode "embedded" -}}`. |
+| `reference/helm/eden/templates/postgres-service.yaml` | Same conditional. |
+| `reference/helm/eden/templates/task-store-server-deployment.yaml` | Replace any hard-coded embedded DSN with a single `env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef: {name: <eden.storeUrlSecretName>, key: <eden.storeUrlSecretKey>}` block (per §3.2.2). Add conditional `volumes: caBundle` + `volumeMounts` for `postgres.tls.caBundleSecret`. Other secret keys (`EDEN_SHARED_TOKEN`, etc.) keep using `envFrom: secretRef:` from 13a. |
+| `reference/helm/eden/templates/secret.yaml` | Conditionally add `EDEN_STORE_URL` to the chart-managed Secret in three sub-cases: (1) `postgres.mode=embedded` AND `secrets.existingSecret == ""` — value is `eden.embeddedDsn` (URL-composed with urlquery'd password + TLS suffix when applicable); (2) `postgres.mode=external` AND `postgres.external.existingSecret == ""` AND `postgres.external.connectionString != ""` — value is the operator-supplied DSN with `eden.tlsSuffix` appended when `tls.enabled=true`; (3) other cases (any `existingSecret`) — the chart-managed Secret omits `EDEN_STORE_URL`; the operator's Secret is the source. |
+| `reference/helm/eden/templates/NOTES.txt` | Add legacy-key-deprecation warning per §3.1.2; add a "you're using mode=external" confirmation block when relevant. |
+| `reference/helm/eden/ci-values-managed-postgres.yaml` (new) | CI values pinning mode=external + minimal storage + TLS off. |
+| `reference/helm/eden/ci-values.yaml` (existing) | Unchanged — still tests embedded. |
+
+### 5.2 No code changes
+
+Per Decision 4 + §1.2: `PostgresStore`, `_postgres_schema.py`,
+`task-store-server.app.build_store`, and `setup-experiment.sh`
+all stay unchanged. The DSN flow already supports both shapes.
+
+### 5.3 New CI
+
+| File | Change |
+|---|---|
+| `.github/workflows/ci.yml` | Add `helm-smoke-managed-postgres` job per §3.10. Mirrors `helm-smoke`'s structure with the sibling-Postgres prelude + `mode=external` install. |
+
+### 5.4 Docs
+
+| File | Change |
+|---|---|
+| `docs/deployment/migrating-to-managed-postgres.md` (new) | Full runbook per §3.8, including provider-specific CA bundle guidance, the Cloud SQL Auth Proxy edge case, the schema-version round-trip verification, and the rollback path. |
+| `docs/deployment/helm.md` (extend) | Add a "Postgres mode" section under the values reference; cover `embedded` (default, 13a behavior) and `external` (managed Postgres). Document the connection-pooler threshold + the future-migration-tool hand-off. |
+| `docs/roadmap.md` Phase 13 entry | Mark 13c complete; cross-link to this plan. |
+
+## 6. Test design
+
+### 6.1 Unit-equivalent (`helm template` matrix)
+
+`helm template` with each combination:
+
+- `mode=embedded` (default): renders the StatefulSet +
+  Service; the chart-managed Secret has an `EDEN_STORE_URL`
+  key whose value is the URL-composed DSN with the
+  `urlquery`-encoded password; the task-store-server Pod's
+  `EDEN_STORE_URL` env sources this key.
+- `mode=external` + `connectionString`: omits StatefulSet;
+  the chart-managed Secret has an `EDEN_STORE_URL` key whose
+  value is the operator-supplied DSN (with the TLS suffix
+  appended at template time when `tls.enabled=true`).
+- `mode=external` + `existingSecret`: omits StatefulSet;
+  the chart-managed Secret omits the `EDEN_STORE_URL` key;
+  the Pod's env sources from
+  `<external.existingSecret>/<external.connectionStringKey>`.
+- `mode=external` + `tls.enabled=true` + `tls.mode=verify-full`
+  with `caBundleSecret` and inline `connectionString`:
+  includes the CA-bundle volume mount; the chart-managed
+  Secret's `EDEN_STORE_URL` value has
+  `?sslmode=verify-full&sslrootcert=/etc/eden/postgres-ca/ca.crt`
+  appended (verified via decoded-Secret grep, since the
+  literal value is base64'd in the rendered Secret YAML).
+- `mode=external` + `tls.enabled=true` + `existingSecret`
+  WITHOUT `tlsAlreadyEncodedInSecret=true`: install fails at
+  lint time per §3.3.1.
+- `mode=external` + `tls.enabled=true` but `caBundleSecret=""`
+  AND `tls.mode=verify-ca`: install fails at lint time.
+- `mode=external` + neither `connectionString` nor
+  `existingSecret`: install fails at lint time.
+- `mode=external` + `connectionString=foo`: install fails at
+  lint time (URL-prefix regex rejects).
+- `mode=external` + libpq keyword DSN
+  (`host=foo dbname=eden user=eden`): install fails at lint
+  time (URL-prefix regex rejects).
+
+Each combination gets a fixture values file under
+`reference/helm/eden/tests/values/` and a small bash test
+that runs `helm template ... | grep` for the expected
+shape. Runs in the new fast `helm-lint` job (introduced
+in 13a §6.1).
+
+### 6.2 `helm-smoke-managed-postgres` integration test
+
+Per §3.10: spin up sibling `postgres:16.6-alpine`, install
+the chart with `mode=external`, run the fixture experiment to
+quiescence, assert the same end-state invariants as
+`helm-smoke` (≥3 `variant.integrated`, ≥9 `task.completed`,
+≥3 ideation-task `task.completed`).
+
+### 6.3 Migration runbook walk-through (manual)
+
+The runbook itself is unit-equivalent-tested by:
+
+- Walking the §3.8.2 Path B steps against a local kind +
+  sibling Postgres setup.
+- Verifying each `kubectl` command output matches what the
+  runbook claims.
+- Verifying `pg_dump`/`pg_restore` round-trips the
+  `schema_version` table.
+
+This isn't part of automated CI (would require a real
+"deploy embedded → snapshot → restore to external → upgrade"
+sequence per CI run, ~5 minutes added). Documented in the
+`Verification gates` checklist below; reviewer verifies once
+before merge.
+
+### 6.4 PostgresStore parametrized test passes against sibling postgres
+
+The existing `EDEN_TEST_POSTGRES_DSN`-gated tests
+([`reference/packages/eden-storage/tests/conftest.py`](../../reference/packages/eden-storage/tests/conftest.py)
+line 128) ALREADY exercise `PostgresStore` against arbitrary
+Postgres DSNs. 13c does not need new test rows; the
+`python-test-postgres` CI job (which runs against
+`postgres:16.6-alpine` as a service container) is itself a
+proxy for "PostgresStore works against an externally-provided
+DSN". This is reassuring for the managed-Postgres path —
+operators run the same `PostgresStore` code that the existing
+test suite has exercised since Phase 10b/10c.
+
+### 6.5 `values.schema.json` rejection tests
+
+Add `reference/helm/eden/tests/schema/` with bash tests:
+
+- `mode=external` + empty DSN: `helm lint` exits non-zero with
+  message about `postgres.external`.
+- `tls.mode=verify-full` + empty `caBundleSecret`: `helm lint`
+  exits non-zero with message about `postgres.tls.caBundleSecret`.
+- `tls.mode=disable` (or `allow`, `prefer`): `helm lint` exits
+  non-zero with message about disallowed TLS modes.
+
+Each test runs under the same fast `helm-lint` job. They are
+the load-bearing protection against the AGENTS.md
+substrate-plan pitfall on operator-required values.
+
+## 7. Verification gates
+
+Before merge:
+
+- `helm lint reference/helm/eden` passes for all six combinations
+  in §6.1 + §6.5.
+- `helm template ... | kubectl apply --dry-run=client -f -`
+  passes for embedded + external (with connectionString) +
+  external (with existingSecret).
+- `helm-lint` CI job passes (fast).
+- `helm-smoke` CI job passes (existing 13a embedded smoke).
+- `helm-smoke-managed-postgres` CI job passes (new).
+- `python-test-postgres` CI job passes (regression check
+  on `PostgresStore`).
+- All other existing CI jobs continue passing
+  (`compose-smoke*`, conformance, lint, type-check).
+- `python3 scripts/check-rename-discipline.py` clean.
+- `python3 scripts/spec-xref-check.py` clean (this plan
+  cites no new spec sections; existing chapter-8 §3 / §1.2 /
+  §7 / §3.2 / §4.2 references are already valid).
+- `npx --yes markdownlint-cli2@0.14.0 docs/plans/eden-phase-13c-managed-postgres.md docs/deployment/migrating-to-managed-postgres.md` passes.
+- Manual verification of the §3.8.2 runbook against a local
+  kind + sibling Postgres.
+
+## 8. Tricky areas
+
+### 8.1 Password URI-encoding for inline DSN
+
+§3.2.3: when an operator uses the inline `connectionString`
+with a password containing reserved URI characters, they MUST
+URI-encode it themselves. The runbook flags this; the
+`values.yaml` comment block flags this. The chart cannot
+auto-encode the password embedded in a full DSN because we
+don't know which `:` is the user-pass delimiter and which is
+inside the password. (We CAN auto-encode for embedded mode
+where the chart owns the username/password fields separately;
+that's existing behavior.)
+
+A future amendment MAY add a `postgres.external.host`,
+`postgres.external.port`, `postgres.external.database`,
+`postgres.external.user`, `postgres.external.password` shape
+that lets the chart compose the DSN with auto-encoding. For
+13c, the inline-DSN-or-existingSecret shape is simpler and
+covers the production case (existingSecret) where encoding is
+the operator's responsibility anyway.
+
+### 8.2 The Cloud SQL Auth Proxy combination (§3.3.4)
+
+Forcing TLS on whenever `mode=external` would break the GCP
+Cloud SQL Auth Proxy use case (which presents
+`127.0.0.1:5432` over plain TCP because the proxy IS the
+secure transport). The chart's default `tls.enabled=false`
+accommodates this without operator intervention. The runbook
+documents:
+
+- Cloud SQL Auth Proxy as a sidecar in the
+  `task-store-server` pod: shipped as a separate manifest the
+  runbook walks the operator through (kubectl patch on the
+  Deployment to add the sidecar). Not a chart template — too
+  GCP-specific.
+- Direct TLS connection to Cloud SQL public IP: requires
+  Cloud SQL's `verify-ca` mode (the cert CN is the instance
+  ID, not a hostname). The runbook covers this combination.
+
+### 8.3 PVC retention on mode-swap
+
+The §3.8.2 Path B runbook's step 6 (helm upgrade with
+`postgres.mode=external`) removes the embedded `StatefulSet`
+but k8s does NOT delete the underlying PVC. This is
+intentional — it's the rollback path. The runbook's step 9
+documents how to free the PVC once the operator is confident
+in the migration. Operators who want a clean uninstall instead
+of mode-swap follow the standard `helm uninstall` +
+`kubectl delete pvc` flow.
+
+A subtle trap: if the operator runs `helm upgrade --force` or
+`helm uninstall && helm install` mid-migration, the PVC
+deletion semantics depend on the StorageClass's `reclaimPolicy`
+(13a §7.1 documented this). For most managed clusters, default
+is `Delete`. The runbook flags this and recommends `helm
+upgrade` (NOT `--force`) for the cutover.
+
+### 8.3a Drain procedure: operator-driven reclaim, not TTL
+
+Worker-host claims (executor / evaluator / ideator hosts)
+carry NO `expires_at` field — verified at
+[`reference/packages/eden-dispatch/src/eden_dispatch/workers.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/workers.py)
+lines 123 and 201, plus the three subprocess hosts'
+`subprocess_mode.py` files. The orchestrator's
+`sweep_expired_claims` at
+[`reference/packages/eden-dispatch/src/eden_dispatch/sweep.py`](../../reference/packages/eden-dispatch/src/eden_dispatch/sweep.py)
+lines 44-46 explicitly skips claims without an `expires_at`,
+so worker-host claims are NOT TTL-reclaimable. Only the Web
+UI's claim path (per
+[`reference/services/web-ui/src/eden_web_ui/cli.py`](../../reference/services/web-ui/src/eden_web_ui/cli.py)
+line 58's `--claim-ttl-seconds`) carries an expiry that the
+sweeper acts on.
+
+§3.8.2 step 1 reflects this by drainin via two mechanisms,
+not TTL:
+
+1. **Graceful SIGTERM submit.** Scaling worker hosts to 0
+   sends SIGTERM; each pod has up to
+   `terminationGracePeriodSeconds` (k8s default 30s) to
+   finish its in-flight task and submit. Tasks that finish
+   transition `claimed` → `submitted` via the existing
+   wire-side submit path; no operator action needed.
+2. **Operator reclaim for stuck claims.** Any task still in
+   `state=claimed` after worker pods terminate gets
+   reclaimed by the operator via the 9e admin module's
+   `Store.reclaim(task_id, "operator")` path or via direct
+   API call. The orchestrator's sweeper plays no role.
+
+This is materially different from the Web-UI session-
+abandonment recovery flow (which IS TTL-based, per the
+chunk-1 §A "stranded-claim recovery via the sweeper"
+pattern). Operator-driven reclaim is the right mechanism
+for migration drains because it's deterministic + bounded
+in time + doesn't depend on a sweeper that may have already
+been scaled down.
+
+A future amendment MAY add `expires_at` to worker-host
+claims (the spec already supports it on the wire side; only
+the worker-host claim invocation paths omit it), which
+would let the sweeper handle worker-host stuck claims too
+and simplify the runbook. That would be a code change in
+the executor/evaluator/ideator hosts plus the Web UI's
+implementer/evaluator/ideator routes (which currently emit
+TTLs only on the operator-claim path), and a behavior change
+operators would need to opt into. Out of scope for 13c; the
+operator-reclaim path is workable today.
+
+A second future amendment MAY add an explicit "drain" CLI
+to the orchestrator + worker hosts that sets a "no new
+claims; finish in-flight work; quiesce" mode and exits
+cleanly, which would let the runbook collapse the two-phase
+scale-down. Out of scope for 13c.
+
+### 8.3b `EDEN_STORE_URL` Secret-key contract — chart upgrade trap
+
+Per §3.2.2, the `task-store-server` always sources
+`EDEN_STORE_URL` from a Secret as a single composed URL —
+never composes one at runtime. The contract is uniform:
+the consumed Secret (chart-managed OR `secrets.existingSecret`
+OR `postgres.external.existingSecret`) MUST contain a key
+whose value is a complete `postgresql://...` URL. The chart's
+`secret.yaml` template builds this for the embedded
+chart-managed case; all other cases require the operator to
+pre-populate the key.
+
+**Chart upgrade trap.** 13a's chart did NOT populate
+`EDEN_STORE_URL` in its existingSecret contract — 13a's
+secret.yaml carried postgresPassword + adminToken +
+giteaAdminPassword + giteaRemotePassword + webUiSessionSecret
+(13a §3.2 / §3.3) and built the DSN at chart-template time
+from `postgresPassword`. 13c moves the DSN composition into
+the Secret value itself, which means a 13a operator using
+`secrets.existingSecret=my-secret` upgrading to chart 0.2.0
+MUST add an `EDEN_STORE_URL` key to `my-secret` before the
+upgrade — otherwise the chart-template-time build of the DSN
+no longer happens (because it can't see the password) and the
+task-store-server pod fails to start with an empty
+`EDEN_STORE_URL`.
+
+Mitigations:
+
+- The chart's NOTES.txt at upgrade time emits an explicit
+  warning when `secrets.existingSecret` is set in
+  `mode=embedded`, instructing the operator to add the
+  `EDEN_STORE_URL` key. (Helm has no visibility into Secret
+  contents from the chart, so this is documentation only,
+  not enforcement.)
+- The `migrating-to-managed-postgres.md` runbook adds a
+  pre-upgrade checklist item: "if you use
+  `secrets.existingSecret`, run `kubectl get secret <name> -o
+  jsonpath='{.data.EDEN_STORE_URL}'` and confirm it's
+  populated; if empty, patch the Secret with the
+  pre-composed DSN before `helm upgrade`".
+- The §6.1 helm-template matrix asserts that the rendered
+  Pod spec's `EDEN_STORE_URL` env entry references a Secret;
+  it cannot assert the Secret's contents.
+
+This trap is the price of the §3.2.2 design choice. The
+alternative — keep template-time DSN composition for
+embedded + chart-managed-secrets, switch to
+"pre-composed-in-Secret" only for external — would split the
+design into two patterns the chart has to maintain. The
+single-pattern shape is worth the one-time upgrade
+documentation.
+
+### 8.4 `ensure_schema` on a non-empty managed database
+
+If the operator points `postgres.mode=external` at a
+non-empty database (one that already has an `experiment` row,
+e.g., from a previous EDEN deployment), the
+`PostgresStore._initialize_experiment` chapter-8 §4.2 reopen-
+immutability check engages
+([`reference/packages/eden-storage/src/eden_storage/postgres.py`](../../reference/packages/eden-storage/src/eden_storage/postgres.py)
+line 192): if the stored `experiment_id` doesn't match the
+chart's, the server fails to start with
+`InvalidPrecondition`. This is the existing safety net; 13c
+inherits it.
+
+The runbook documents the check and recommends operators
+target a fresh empty database for path A (fresh deployment)
+and `pg_restore` into a fresh empty database for path B
+(migration).
+
+### 8.5 `EDEN_STORE_URL` envFrom vs valueFrom
+
+Per §3.2.2 the chart sources `EDEN_STORE_URL` from a Secret
+as a single pre-composed URL — no template-time DSN
+composition, no `$(VAR)` expansion across env entries, no
+runtime-side string assembly. The chart uses an explicit
+`env: - name: EDEN_STORE_URL; valueFrom: secretKeyRef:
+{name: ..., key: ...}` entry for this specific variable. The
+other deployment credentials (`EDEN_SHARED_TOKEN`,
+`EDEN_SESSION_SECRET`) keep coming through `envFrom:
+secretRef:` from 13a.
+
+This sidesteps the env-ordering trap that arose when an
+earlier draft tried to compose `EDEN_STORE_URL` from
+`EDEN_STORE_URL_RAW` plus a TLS suffix via `$(VAR)`-expansion
+in `args:`: Kubernetes' `$(VAR)` resolution requires the
+referenced variable to be defined earlier in the same `env:`
+list (per the
+[Kubernetes env reference](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)),
+which made the helm-template ordering load-bearing. The
+"single pre-composed value in the Secret" approach removes
+that fragility entirely. The TLS suffix is always baked into
+the Secret value at template time (or, for external +
+`existingSecret` + `tls.enabled`, baked in by the operator
+per §3.3.1's `tlsAlreadyEncodedInSecret` flag).
+
+### 8.6 Cluster-IP reachability of the sibling Postgres in CI
+
+The `helm-smoke-managed-postgres` CI job runs Postgres as a
+sibling Docker container on the `kind` Docker network
+(§3.10). For pods inside the kind cluster to reach
+`eden-ci-pg:5432`, the kind cluster's internal CoreDNS must
+resolve `eden-ci-pg` — which it does NOT by default; CoreDNS
+only resolves Service DNS. The fix:
+
+- Use the sibling container's IP address directly: capture
+  via `docker inspect -f '{{...IPAddress}}' eden-ci-pg`,
+  template the DSN at job-creation time. Per AGENTS.md "CI
+  failure diagnosis: local repro beats log-tail reading",
+  this is exactly the kind of trap the local-repro flow
+  catches, so the §3.10 job spec uses the IP, not the
+  container name. Documented in the job's inline comments.
+
+Alternative: deploy a headless `Service` in the kind cluster
+that points at the sibling container's IP via
+`Endpoints`. More moving pieces; the IP-direct approach is
+simpler.
+
+### 8.7 The `existingSecret` precedence semantics
+
+When BOTH `postgres.external.connectionString` AND
+`postgres.external.existingSecret` are set, `_helpers.tpl`'s
+`eden.storeUrl` ignores `connectionString` and uses
+`existingSecret`. This avoids a confusing failure mode where
+`helm template` would happily emit both (one in the chart-
+managed Secret, one referenced via existingSecret) and the
+operator wouldn't know which one wins.
+
+The values comment + the schema's `anyOf` clause both
+document this. The comment specifically warns: "if you set
+existingSecret, leave connectionString empty to avoid
+shipping a Secret you don't intend to use".
+
+### 8.8 Failed `pg_restore` mid-migration
+
+If §3.8.2 step 3 (`pg_restore` into managed Postgres) fails
+midway — partial table creation, network drop, permission
+error — the runbook says:
+
+1. Drop the partially-restored target database (or
+   `DROP TABLE IF EXISTS` for each EDEN table).
+2. Re-create empty.
+3. Re-run `pg_restore`.
+
+`pg_restore --clean --if-exists` would handle this, but
+runbooks that drop tables silently are dangerous if the
+target is the WRONG database; the explicit step-by-step is
+safer for operators new to the flow.
+
+### 8.9 Operator upgrade from chart 0.1.0 (13a) without migrating to external
+
+The default `postgres.mode=embedded` is the chart 0.2.0
+upgrade-safe path: 13a operators upgrading without changing
+their `values.yaml` get the same StatefulSet they had,
+attached to the same PVC. The legacy flat keys (per §3.1.2)
+fall through with a NOTES.txt warning.
+
+The §3.8.2 runbook is opt-in; it's there for operators who
+WANT to migrate to external. Operators who don't are
+unaffected.
+
+### 8.10 Migration tooling discontinuity (Decision 4 follow-up)
+
+If a future chunk drops `ensure_schema` in favor of an
+operator-run migration tool (Alembic / sqitch), the swap is
+breaking for 13c-era deployments. The future tool MUST:
+
+- Read the existing `schema_version` table (the bootstrap
+  table 13c writes) and treat any non-zero version as
+  "v1 already applied".
+- Otherwise import the current schema state as v1 and proceed
+  from there.
+
+This load-bearing constraint is captured in the future-
+amendment hand-off section of `docs/deployment/helm.md`
+(extended in 13c) so the chunk introducing the migration
+tool sees the requirement up front.
+
+## 9. Risks
+
+1. **Operators inline a DSN with a special-char password.**
+   Mitigation: `values.yaml` comment + runbook flag URI-
+   encoding requirement (§3.2.3); strongly recommend
+   `existingSecret` for production.
+
+2. **TLS-required managed providers default to plaintext.**
+   The chart's default `tls.enabled=false` means a fresh
+   `mode=external` install against RDS / Cloud SQL fails at
+   psycopg connection time with a TLS-handshake error. The
+   error message is reasonably clear ("server requires SSL")
+   but not chart-specific. Mitigation: runbook + values
+   comment recommend turning on TLS for any managed provider;
+   the §3.8.1 fresh-deployment walkthrough enables it.
+
+3. **Schema bootstrap race in a future multi-replica
+   `task-store-server`.** §3.5.2 flags this. The first
+   `task-store-server` replica that connects runs
+   `ensure_schema` and creates tables; a second concurrent
+   replica's `CREATE TABLE` would fail. Today there's only
+   one replica so the race is impossible. A future
+   multi-replica rollout MUST add a transactional advisory
+   lock to `_postgres_schema.ensure_schema`. Documented as
+   a load-bearing constraint on that future chunk.
+
+4. **`pg_dump`/`pg_restore` version mismatch.** The runbook
+   recommends matching `pg_dump` and `pg_restore` versions
+   (both 16.x). A `pg_dump 14` against a Postgres 16 source
+   produces a dump that `pg_restore 16` can read but that
+   may miss new-in-16 features (none of which EDEN uses, but
+   future schema migrations might). Mitigation: runbook
+   pins `pg_dump`/`pg_restore` version to the source
+   Postgres major version.
+
+5. **`existingSecret` typos.** An operator setting
+   `postgres.external.existingSecret=eden-managed-pg-typo`
+   (referencing a non-existent secret) gets a Pod that
+   fails to start with "MountVolume.SetUp failed: secret
+   not found". The chart has no way to validate Secret
+   existence at template time; this is a Kubernetes runtime
+   concern. Mitigation: the runbook's verification step
+   (`kubectl get pods -n eden-prod` after `helm upgrade`)
+   catches this within seconds.
+
+6. **The chart's deprecation cadence.** §3.1.2's one-version
+   fallback (chart 0.2.0 supports flat keys; 0.3.0 drops
+   them) requires operators to migrate `values.yaml` before
+   chart 0.3.0. Risk: an operator on chart 0.2.0 customizes
+   `postgres.image.tag`, never sees the NOTES.txt warning,
+   then `helm upgrade` to 0.3.0 silently uses the chart-
+   default image. Mitigation: NOTES.txt visibility, plus a
+   pre-0.3.0 chart release that converts the warning to an
+   `error` (lint failure on legacy keys). 13c only ships
+   0.2.0; the conversion is a future-chunk concern.
+
+7. **CI sibling Postgres connectivity (§3.10 + §8.6).** The
+   kind-network sibling-container approach is fragile across
+   GitHub Actions runner version changes. Mitigation: the
+   job uses container IPs (not names) per §8.6; documented
+   in inline comments. Alternative kept in reserve:
+   `kind`'s `extraMounts` + a dedicated kind config with
+   `extraPortMappings`.
+
+## 10. Sequencing
+
+Recommended PR shape (in order):
+
+1. **Values + schema PR.** `values.yaml` reorganization
+   (`postgres.embedded.*`, `postgres.external.*`,
+   `postgres.tls.*`); `values.schema.json` clauses;
+   `_helpers.tpl` additions (`eden.storeUrl`,
+   `eden.tlsSuffix`); NOTES.txt deprecation warning. Lints
+   clean for both modes; `mode=embedded` unchanged from
+   13a; `mode=external` works at template time but no
+   integration test yet.
+
+2. **Template wiring PR.** `postgres-statefulset.yaml` +
+   `postgres-service.yaml` conditionals;
+   `task-store-server-deployment.yaml` rewiring;
+   `secret.yaml` conditional `EDEN_STORE_URL` key. Existing
+   `helm-smoke` (embedded) still passes.
+
+3. **CI PR.** `helm-smoke-managed-postgres` job;
+   `ci-values-managed-postgres.yaml`; `helm-lint` matrix
+   extension for the new schema clauses. `helm-smoke-
+   managed-postgres` first run validates the managed-
+   Postgres path end-to-end.
+
+4. **Runbook + docs PR.** `migrating-to-managed-postgres.md`
+   (new); `helm.md` extended with the Postgres-mode
+   reference; roadmap delta. Runbook's manual walkthrough is
+   verified by the reviewer against a local kind cluster.
+
+A reviewer going from PR 1 to PR 4 should expect
+`helm-smoke-managed-postgres` to first appear in PR 3 and
+go green on first run; if it doesn't, the failure mode is
+almost certainly the §8.6 cluster-IP-reachability issue.
+
+## 11. Out of scope (future amendments)
+
+- **Migration tooling (Alembic / sqitch).** §3.5; future
+  chunk that introduces the first non-trivial schema
+  migration. Constraint captured per Decision 4 + §8.10:
+  the migration tool MUST recognize `schema_version` as
+  v1-applied so 13c-era deployments aren't re-migrated.
+- **Connection pooler (PgBouncer / pgcat).** §3.4; future
+  chunk that introduces multi-replica `task-store-server`.
+- **Read-replica routing.** §3.6; depends on multi-replica
+  server.
+- **Multi-region replication.** Provider-side; no chart
+  changes in scope.
+- **Cloud SQL Auth Proxy as a chart-shipped sidecar.**
+  §8.2; provider-specific, kept in the runbook.
+- **Auto-managed credentials via External Secrets Operator
+  / Vault Agent Injector.** Operators wire these through
+  `existingSecret` today; chart-native integration is a
+  future amendment.
+- **`pg_dump`/`pg_restore` Job-as-helm-hook.** Could be a
+  pre-upgrade hook the chart runs automatically, but that
+  ties EDEN to a specific migration tool's lifecycle and
+  removes the operator's ability to gate cutover; runbook
+  is the right shape for v0.
+- **Decomposing `postgres.external.connectionString` into
+  host/port/db/user/password fields.** §8.1; would let the
+  chart auto-encode passwords. Not load-bearing today
+  because production deployments use `existingSecret`.
+- **Strict `task-store-server` resource requests/limits
+  tuned for managed-Postgres workloads.** 13a defaults
+  apply; cluster-autoscaler hints are a separate concern.
+
+## 12. Estimated effort
+
+- **Values + schema** (PR 1): ~1 day. Layout decisions,
+  helper functions, NOTES.txt copy.
+- **Template wiring** (PR 2): ~1 day. Conditional
+  rendering, secret wiring, env-var ordering trap (§8.5).
+- **CI** (PR 3): ~1.5 days. Sibling-Postgres setup, IP
+  templating, schema-rejection tests, debugging the kind-
+  network reachability path on a real GitHub Actions
+  runner.
+- **Runbook + docs** (PR 4): ~1.5 days. Runbook is
+  detail-heavy (provider-specific CA bundles, Cloud SQL
+  Auth Proxy edge case, `pg_dump`/`pg_restore` walkthrough,
+  rollback path). Reviewer verifies runbook against local
+  kind cluster (~1h additional).
+
+**Realistic total: ~5 working days** of focused work. The
+heaviest single item is the runbook (PR 4); the chart
+changes themselves are mechanical given the 13a foundation.
+
+## 13. What lands at the end of 13c
+
+After 13c merges, an operator can run `helm install eden
+./reference/helm/eden -f values.yaml` against any conforming
+Kubernetes cluster, point `postgres.mode=external` at a managed
+Postgres DSN they've provisioned out-of-band (RDS, Cloud SQL,
+AlloyDB, Supabase, Neon, Crunchy Bridge, etc.), and get a
+production-grade EDEN deployment running the full Phase-12
+protocol with provider-managed durability + backup + failover.
+The embedded `StatefulSet` path stays for greenfield clusters
+and test environments. The Compose deployment is unchanged.
+13d (S3/GCS blob backend) and 13e (Gitea auth + ACLs + PR
+review) extend the chart along orthogonal axes — neither
+depends on 13c.

--- a/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/7.patch
+++ b/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/7.patch
@@ -1,0 +1,20 @@
+--- /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/6.md	2026-05-08 12:31:48
++++ /Users/ericalt/Documents/eden-worktrees/phase-13cde-substrate-plans/docs/plans/eden-phase-13c-managed-postgres.md	2026-05-08 12:32:31
+@@ -1137,7 +1137,7 @@
+ 
+ 4. **Verify the schema_version round-trip.** Connect to the
+    managed instance and confirm against the baselines captured
+-   in step 1a:
++   in step 2:
+ 
+    ```sql
+    SELECT MAX(version) FROM schema_version;
+@@ -1190,7 +1190,7 @@
+      curl -s http://localhost:8080/healthz
+    # Walk the events cursor to count total events. Compare
+    # the result against the wire-side baseline captured in
+-   # step 1a (the "wire-baseline events:" line).
++   # step 2 (the "wire-baseline events:" line).
+    # cursor=0 returns the first batch; the response includes a
+    # forward `cursor` to feed the next call.
+    #


### PR DESCRIPTION
## Summary

Plan for Phase 13c — adds a `postgres.mode={embedded,external}` switch to the 13a Helm chart so operators can point the task-store-server at a managed Postgres (RDS, Cloud SQL, AlloyDB, Supabase, Neon, Crunchy Bridge, etc.) instead of the in-cluster StatefulSet that 13a bundles. Embedded stays the default; chart upgrade from 13a is a no-op for any operator who doesn't opt in.

Plan: [`docs/plans/eden-phase-13c-managed-postgres.md`](docs/plans/eden-phase-13c-managed-postgres.md).

## Load-bearing decisions (§2)

1. **Two coexisting Postgres modes via `postgres.mode` enum, default `embedded`.** Chart upgrade from 13a is no-op; opt-in to managed Postgres via values.
2. **DSN is operator-supplied. No fictional default.** `values.schema.json`'s `if/then` clause requires non-empty `connectionString` (URL-form regex enforced) OR `existingSecret + connectionStringKey` when `mode=external`.
3. **No connection pooler in v0; document the threshold.** Single-replica task-store-server, one psycopg connection per process. Pooler becomes load-bearing when chart adds multi-replica server (out of scope for 13-series).
4. **Schema management stays `ensure_schema`-on-first-connect; defer Alembic/sqitch.** First non-trivial migration is the trigger to introduce migration tooling. Future tool MUST recognize `schema_version` table 13c writes (load-bearing constraint captured).
5. **TLS posture: opt-in, with verify-full recommended for managed providers.** Cloud SQL Auth Proxy edge case documented (proxy IS the secure transport, so `tls.enabled=false` is correct there).
6. **Failover and read-replicas out of scope.** Single writer DSN; managed provider's failover endpoint handles failover transparently.
7. **Backup is operator/provider concern.** EDEN documents what needs to persist (7 tables) plus the 12b portable-checkpoints hand-off.
8. **Migration from embedded → external is a runbook, not scripted automation.** Per AGENTS.md substrate-plan pitfall on multi-tenant lifecycle.
9. **Coexistence with 13a preserved by chart-default embedded mode.** One-version backward-compat fallback for the legacy flat `postgres.*` keys (chart 0.2.0 supports; 0.3.0 drops).
10. **CI: `helm-smoke-managed-postgres` job stands up Postgres outside the kind cluster** (sibling Docker container, addressed by IP per CoreDNS limitation, not container name).

Plus the §3.2.2 design conclusion: **the chart never composes the DSN at runtime** — both modes converge on a Secret containing a single pre-composed `EDEN_STORE_URL` URL. Avoids the urlquery-without-the-password failure mode under `existingSecret`. New `tlsAlreadyEncodedInSecret` ack flag for the external+existingSecret+TLS combination so the chart doesn't silently mis-append a sslmode suffix.

## Out of scope (§11)

- Migration tooling (Alembic / sqitch) — future chunk; first non-trivial migration is the trigger.
- Connection pooler (PgBouncer / pgcat) — future amendment; depends on multi-replica server.
- Read-replica routing — depends on multi-replica server.
- Cloud SQL Auth Proxy as chart-shipped sidecar — provider-specific; runbook covers it.
- Auto-managed credentials via External Secrets Operator / Vault Agent Injector — operators wire through `existingSecret` today.
- Multi-region replication — provider-side.
- Decomposed `host/port/db/user/password` for external (chart auto-encoding) — covered by `existingSecret` in production.

## Test plan

- [ ] `helm lint` passes for embedded + external (connectionString) + external (existingSecret) + external+TLS combinations
- [ ] `helm template ... | kubectl apply --dry-run=client -f -` passes for each mode
- [ ] `values.schema.json` rejects: empty DSN with `mode=external`; non-URL DSN; `tls.mode=verify-full` with empty `caBundleSecret`; external+existingSecret+TLS without `tlsAlreadyEncodedInSecret=true`
- [ ] `helm-smoke` (existing 13a embedded smoke) continues passing
- [ ] `helm-smoke-managed-postgres` (new) — sibling Postgres + IP-based DSN; asserts ≥3 `variant.integrated`, ≥9 `task.completed`, ≥3 ideation-task `task.completed`
- [ ] `helm-upgrade-smoke` confirms 13a → 13c upgrade preserves PVC + schema_version
- [ ] `python-test-postgres` regression check on `PostgresStore`
- [ ] `python3 scripts/check-rename-discipline.py` clean
- [ ] `python3 scripts/spec-xref-check.py` clean
- [ ] Manual walkthrough of §3.8.2 Path B runbook against local kind + sibling Postgres

## Codex review

7 rounds (0-6) to convergence. Round 0 surfaced 4 substantive feasibility issues (URL-form DSN constraint, drain ordering vs sweeper, embedded-mode DSN composition under `existingSecret`, ideator-host workload kind). Rounds 1-5 addressed those plus three command-level drifts the reviewer caught while iterating (wire endpoint shapes `/v0/experiments/{E}/...` not `/v1/...`; `events?cursor` not `events?limit`; `bash -c` single-quoted shell-expansion bug for `$TOKEN`). Round 6 caught the missing pre-snapshot baseline-capture step and an editorial step-numbering inconsistency. Final review confirms convergence.

Run record at [`docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/`](docs/plans/review/eden-phase-13c-managed-postgres/20260508T121152/) — snapshots `0.md`-`7.md` plus reviews `0-review.md`-`6-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)