### PR TITLE
Issue #107: Add artifacts directory listing to admin web UI

### DIFF
--- a/reference/services/web-ui/src/eden_web_ui/app.py
+++ b/reference/services/web-ui/src/eden_web_ui/app.py
@@ -23,6 +23,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .routes import admin as admin_routes
+from .routes import admin_artifacts as admin_artifacts_routes
 from .routes import admin_experiments as admin_experiments_routes
 from .routes import admin_groups as admin_groups_routes
 from .routes import admin_workers as admin_workers_routes
@@ -112,6 +113,7 @@ def make_app(
     app.include_router(admin_routes.router)
     app.include_router(admin_workers_routes.router)
     app.include_router(admin_groups_routes.router)
+    app.include_router(admin_artifacts_routes.router)
     app.include_router(artifacts_routes.router)
     if control_plane is not None:
         app.include_router(admin_experiments_routes.router)

--- a/reference/services/web-ui/src/eden_web_ui/routes/admin_artifacts.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/admin_artifacts.py
@@ -1,0 +1,118 @@
+"""Read-only directory listing of the configured ``--artifacts-dir``.
+
+Issue #107: the existing :mod:`eden_web_ui.routes.artifacts` route
+serves an artifact file given a ``file://`` URI, but offers no way
+to *discover* what artifacts exist. Operators wanting to verify
+"did the executor write anything?" or "what's in this evaluation's
+output?" have had to ``docker exec`` into the web-ui container or
+read the host bind-mount directly. This module surfaces that
+content in-UI as a peer of the other ``/admin/*`` inspection
+surfaces (tasks, ideas, variants, events, workers, groups).
+
+Trust boundary mirrors :func:`eden_web_ui.routes._helpers._read_inline_artifact`:
+
+- Listing is rooted at ``app.state.artifacts_dir.resolve()`` and
+  never escapes it. Each directory entry is ``resolve()``-ed and
+  its containment re-checked, so symlinks pointing outside the jail
+  are silently skipped.
+- Authenticated callers only (302 redirect to ``/signin`` otherwise),
+  matching the existing ``GET /artifacts`` posture.
+- Read-only. Per the issue, "upload, delete, or any write operation
+  ... is worker-write-only by design" — this module surfaces no
+  mutation controls.
+
+The empty listing is the *expected* state for scripted-mode
+deployments (the URIs in submissions are fictional pointers; only
+subprocess mode writes real bytes), so the template carries a
+banner explaining that to head off "why is this blank?" friction.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from ._helpers import get_session
+
+router = APIRouter(prefix="/admin/artifacts")
+
+
+@dataclass(frozen=True)
+class _ArtifactEntry:
+    rel_path: str
+    size: int
+    mtime: str
+    serve_uri: str
+
+
+def _format_mtime(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=UTC).isoformat(timespec="seconds")
+
+
+def _walk_artifacts(base: Path) -> list[_ArtifactEntry]:
+    """Recursively enumerate regular files under ``base``.
+
+    Each candidate is ``resolve()``-ed and its containment within
+    ``base`` re-checked: a symlink pointing outside the jail (or to
+    a non-file inode) is silently skipped rather than surfaced. The
+    artifacts dir is operator-curated (workers write into it; the UI
+    only reads), so the design choice is to drop silently rather
+    than surface "skipped N files for safety" — the listing is a
+    convenience, not an audit log.
+    """
+    out: list[_ArtifactEntry] = []
+    for dirpath, _dirnames, filenames in os.walk(base, followlinks=False):
+        for name in filenames:
+            candidate = Path(dirpath) / name
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                continue
+            if not resolved.is_relative_to(base):
+                continue
+            if not resolved.is_file():
+                continue
+            try:
+                stat = resolved.stat()
+            except OSError:
+                continue
+            rel = resolved.relative_to(base).as_posix()
+            out.append(
+                _ArtifactEntry(
+                    rel_path=rel,
+                    size=stat.st_size,
+                    mtime=_format_mtime(stat.st_mtime),
+                    serve_uri=f"file://{resolved}",
+                )
+            )
+    out.sort(key=lambda e: e.rel_path)
+    return out
+
+
+@router.get("/", response_class=HTMLResponse, response_model=None)
+async def artifacts_index(request: Request) -> HTMLResponse | RedirectResponse:
+    """List files under the configured ``--artifacts-dir``."""
+    session = get_session(request)
+    if session is None:
+        return RedirectResponse(url="/signin", status_code=303)
+
+    base = Path(request.app.state.artifacts_dir).resolve()
+    entries = _walk_artifacts(base)
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "admin_artifacts.html",
+        {
+            "session": session,
+            "artifacts_dir": str(base),
+            "entries": entries,
+        },
+    )
+
+
+__all__ = ["router"]

--- a/reference/services/web-ui/src/eden_web_ui/routes/admin_artifacts.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/admin_artifacts.py
@@ -87,7 +87,14 @@ def _walk_artifacts(base: Path) -> list[_ArtifactEntry]:
                     rel_path=rel,
                     size=stat.st_size,
                     mtime=_format_mtime(stat.st_mtime),
-                    serve_uri=f"file://{resolved}",
+                    # ``Path.as_uri()`` percent-encodes path bytes that
+                    # are reserved in a URI (``?``, ``#``, ``%``, …).
+                    # ``f"file://{resolved}"`` is wrong for those: a
+                    # filename like ``a?b.txt`` would round-trip
+                    # through the template's ``urlencode`` and the
+                    # serving route's ``urlparse`` as path ``a`` +
+                    # query ``b.txt``, returning 404.
+                    serve_uri=resolved.as_uri(),
                 )
             )
     out.sort(key=lambda e: e.rel_path)

--- a/reference/services/web-ui/src/eden_web_ui/templates/admin_artifacts.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/admin_artifacts.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}EDEN — admin artifacts{% endblock %}
+{% block main %}
+<h1>artifacts</h1>
+
+<p class="lead">
+    Read-only directory listing of <code>{{ artifacts_dir }}</code>
+    (the configured <code>--artifacts-dir</code>). Each entry links
+    to the existing <code>/artifacts?uri=&hellip;</code> serving route.
+</p>
+
+{% if not entries %}
+<div class="banner banner-warn">
+    no artifact files found.
+    scripted-mode deployments produce no artifact files; this is
+    the expected empty state. Subprocess-mode workers (ideator /
+    executor / evaluator with a <code>*_command</code> configured)
+    write real bytes here.
+</div>
+{% else %}
+<section>
+    <h2>files ({{ entries | length }})</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>path</th>
+                <th>size (bytes)</th>
+                <th>mtime (UTC)</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for e in entries %}
+            <tr>
+                <td><a href="/artifacts?uri={{ e.serve_uri | urlencode }}"><code>{{ e.rel_path }}</code></a></td>
+                <td>{{ e.size }}</td>
+                <td>{{ e.mtime }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>
+{% endif %}
+{% endblock %}

--- a/reference/services/web-ui/src/eden_web_ui/templates/admin_index.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/admin_index.html
@@ -88,6 +88,11 @@
 </section>
 
 <section>
+    <h2>artifacts</h2>
+    <p><a href="/admin/artifacts/">browse <code>--artifacts-dir</code> &raquo;</a></p>
+</section>
+
+<section>
     <h2>orchestrator controls</h2>
     <p>
         <a href="/admin/dispatch-mode/">dispatch_mode toggles &raquo;</a> &mdash;

--- a/reference/services/web-ui/tests/test_admin_artifacts_routes.py
+++ b/reference/services/web-ui/tests/test_admin_artifacts_routes.py
@@ -1,0 +1,117 @@
+"""Per-route tests for the artifacts directory-listing admin module.
+
+Issue #107: ``GET /admin/artifacts/`` lists files under the
+configured ``--artifacts-dir`` recursively, each linking to the
+existing ``GET /artifacts?uri=file://...`` serving route. Tests
+cover auth gate, empty-state banner, populated render, recursive
+walk, and path-containment (symlink-escape + ``..``-escape).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import quote
+
+from fastapi.testclient import TestClient
+
+
+class TestAdminArtifactsAuthGate:
+    def test_get_redirects_unauthenticated(self, client: TestClient) -> None:
+        resp = client.get("/admin/artifacts/", follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == "/signin"
+
+
+class TestAdminArtifactsEmptyState:
+    def test_empty_dir_renders_banner(self, signed_in_client: TestClient) -> None:
+        resp = signed_in_client.get("/admin/artifacts/")
+        assert resp.status_code == 200
+        assert "no artifact files found" in resp.text
+        assert "scripted-mode deployments produce no artifact files" in resp.text
+
+
+class TestAdminArtifactsPopulated:
+    def test_lists_file_with_size_mtime_and_serve_link(
+        self,
+        signed_in_client: TestClient,
+        artifacts_dir: Path,
+    ) -> None:
+        target = artifacts_dir / "idea-demo.md"
+        target.write_text("hello world\n")
+        resp = signed_in_client.get("/admin/artifacts/")
+        assert resp.status_code == 200
+        assert "idea-demo.md" in resp.text
+        # File size in bytes appears verbatim.
+        assert str(target.stat().st_size) in resp.text
+        # The serve link points at /artifacts?uri=file://<resolved>.
+        # Jinja's ``urlencode`` filter leaves "/" unescaped (safe="/"),
+        # matching ``urllib.parse.quote``'s default.
+        expected_uri = quote(f"file://{target.resolve()}", safe="/")
+        assert f"/artifacts?uri={expected_uri}" in resp.text
+
+    def test_recursive_walk_at_depth_gt_one(
+        self,
+        signed_in_client: TestClient,
+        artifacts_dir: Path,
+    ) -> None:
+        nested = artifacts_dir / "a" / "b" / "c"
+        nested.mkdir(parents=True)
+        (nested / "deep.txt").write_text("payload")
+        resp = signed_in_client.get("/admin/artifacts/")
+        assert resp.status_code == 200
+        assert "a/b/c/deep.txt" in resp.text
+
+    def test_link_back_to_artifact_serves_file(
+        self,
+        signed_in_client: TestClient,
+        artifacts_dir: Path,
+    ) -> None:
+        target = artifacts_dir / "served.txt"
+        target.write_text("served-bytes")
+        resp = signed_in_client.get(
+            f"/artifacts?uri=file://{target.resolve()}",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 200
+        assert resp.text == "served-bytes"
+
+
+class TestAdminArtifactsContainment:
+    def test_symlink_to_outside_jail_is_skipped(
+        self,
+        signed_in_client: TestClient,
+        artifacts_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        outside = tmp_path / "outside-secret.txt"
+        outside.write_text("do-not-leak")
+        link = artifacts_dir / "escape.txt"
+        os.symlink(outside, link)
+        resp = signed_in_client.get("/admin/artifacts/")
+        assert resp.status_code == 200
+        # The symlink target lives outside artifacts_dir and must be
+        # silently dropped — neither the path nor any payload bytes
+        # may leak into the rendered listing.
+        assert "escape.txt" not in resp.text
+        assert "outside-secret.txt" not in resp.text
+        assert "do-not-leak" not in resp.text
+
+    def test_traversal_uri_returns_404_from_serving_route(
+        self,
+        signed_in_client: TestClient,
+        artifacts_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        # The listing endpoint never accepts a path from the caller,
+        # so traversal containment is enforced exclusively at the
+        # serving route. Sanity-check the existing posture here so a
+        # future refactor that lets the listing accept caller-supplied
+        # paths still has explicit test coverage.
+        outside = tmp_path / "outside.txt"
+        outside.write_text("nope")
+        resp = signed_in_client.get(
+            f"/artifacts?uri=file://{outside.resolve()}",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 404

--- a/reference/services/web-ui/tests/test_admin_artifacts_routes.py
+++ b/reference/services/web-ui/tests/test_admin_artifacts_routes.py
@@ -10,6 +10,7 @@ walk, and path-containment (symlink-escape + ``..``-escape).
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from urllib.parse import quote
 
@@ -44,10 +45,11 @@ class TestAdminArtifactsPopulated:
         assert "idea-demo.md" in resp.text
         # File size in bytes appears verbatim.
         assert str(target.stat().st_size) in resp.text
-        # The serve link points at /artifacts?uri=file://<resolved>.
-        # Jinja's ``urlencode`` filter leaves "/" unescaped (safe="/"),
-        # matching ``urllib.parse.quote``'s default.
-        expected_uri = quote(f"file://{target.resolve()}", safe="/")
+        # The serve link is a real RFC-8089 file URI produced by
+        # ``Path.as_uri()`` (percent-encodes reserved chars in the
+        # path), then re-encoded by Jinja's ``urlencode`` filter for
+        # safe inclusion in the querystring.
+        expected_uri = quote(target.resolve().as_uri(), safe="/")
         assert f"/artifacts?uri={expected_uri}" in resp.text
 
     def test_recursive_walk_at_depth_gt_one(
@@ -75,6 +77,47 @@ class TestAdminArtifactsPopulated:
         )
         assert resp.status_code == 200
         assert resp.text == "served-bytes"
+
+    def test_rendered_link_round_trips_for_reserved_chars(
+        self,
+        signed_in_client: TestClient,
+        artifacts_dir: Path,
+    ) -> None:
+        """Filenames containing URI-reserved chars (``?`` / ``#``)
+        must produce links that round-trip to the serving route.
+
+        Codex round-0 finding: ``serve_uri = f"file://{resolved}"``
+        wasn't a valid file URI for these chars — the listing
+        rendered a clickable link that 404'd when followed because
+        ``urlparse`` split the path at the unescaped ``?``. The fix
+        is ``Path.as_uri()`` (percent-encodes reserved bytes).
+        """
+        for name, payload in (
+            ("a?b.txt", "with-question"),
+            ("c#d.txt", "with-hash"),
+            ("e f.txt", "with-space"),
+        ):
+            target = artifacts_dir / name
+            target.write_text(payload)
+            resp = signed_in_client.get("/admin/artifacts/")
+            assert resp.status_code == 200
+            match = re.search(
+                r'href="(/artifacts\?uri=[^"]+)">\s*<code>'
+                + re.escape(name)
+                + r"</code>",
+                resp.text,
+            )
+            assert match is not None, (
+                f"no listing link found for {name}; response was: {resp.text}"
+            )
+            follow = signed_in_client.get(
+                match.group(1), follow_redirects=False
+            )
+            assert follow.status_code == 200, (
+                f"following the rendered link for {name} returned "
+                f"{follow.status_code}"
+            )
+            assert follow.text == payload
 
 
 class TestAdminArtifactsContainment:


### PR DESCRIPTION
Closes #107.

## Summary

- Add `GET /admin/artifacts/`: a read-only directory listing of every regular file under the configured `--artifacts-dir`, recursively, with size + mtime per entry.
- Each entry links back to the existing `GET /artifacts?uri=file://<resolved-path>` serving route, so clicking through renders the file via the unchanged serving primitive.
- Same session-cookie auth posture as `/artifacts` — unauthenticated GETs redirect to `/signin`.
- Path-containment mirrors `_read_inline_artifact` from `routes/_helpers.py`: each candidate is `resolve()`-ed and `is_relative_to(artifacts_dir.resolve())`-checked, so symlinks pointing outside the jail (and non-file inodes) are silently dropped from the listing.
- Empty-state banner explains that scripted-mode deployments produce no artifact files — heading off "why is this blank?" support traffic per the issue.

## Out of scope (per issue)

- Upload, delete, or any write operation.
- Non-`file://` URIs (S3 / portable backends — deferred to #102).
- Cross-referencing artifacts to idea / variant / submission records (the issue's "optional extensions" — deferable; surface if it grows operator-painful).
- Pagination / max-files cap (deferable; the artifacts dir is bounded by experiment activity).

## Structure

- New module `routes/admin_artifacts.py` (peer of `admin_workers.py` / `admin_groups.py`; not part of `admin.py` so it survives PR #105's `admin.py` → `admin/` refactor cleanly).
- New template `admin_artifacts.html`.
- Link added to the admin index.
- Per-route tests in `tests/test_admin_artifacts_routes.py` cover auth gate, empty-state banner, populated rendering (size + mtime + correct link target), recursive walk at depth > 1, and symlink-out / traversal containment.

## Test plan

- [x] `uv run pytest -q` (1769 passed, 216 skipped)
- [x] `uv run ruff check .`
- [x] `uv run pyright` (0 errors)
- [x] `npx --yes markdownlint-cli2@0.14.0 ...`
- [x] `python3 scripts/check-rename-discipline.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)