### PR TITLE
Fix #119: drop blob-init from eden-experiment NON_WORKER_SERVICES

### DIFF
--- a/reference/scripts/manual-ui/eden-experiment
+++ b/reference/scripts/manual-ui/eden-experiment
@@ -50,7 +50,6 @@ ORPHAN_VOLUMES=(
 NON_WORKER_SERVICES=(
     postgres
     forgejo
-    blob-init
     task-store-server
     orchestrator
     web-ui


### PR DESCRIPTION
Closes #119.

`blob-init` was removed from `reference/compose/compose.yaml` in Phase 12a-1g (bind-mount conversion), but the manual-UI wrapper at `reference/scripts/manual-ui/eden-experiment` still listed it in `NON_WORKER_SERVICES`. As a result, `eden-experiment up` failed post-setup with `no such service: blob-init`.

## Summary
- Drop `blob-init` from the `NON_WORKER_SERVICES` array in `reference/scripts/manual-ui/eden-experiment`.

## Test plan
- [x] `grep -rn blob-init reference/scripts/` returns no matches.
- [x] `bash -n reference/scripts/manual-ui/eden-experiment` passes.
- [ ] CI smoke / compose-smoke jobs pass.
- [ ] Manual `eden-experiment up tests/fixtures/experiment/.eden/config.yaml --experiment-id test-119` brings up postgres / forgejo / task-store-server / orchestrator / web-ui without `no such service` error (skipped locally — auto-mode classifier blocked the prerequisite eden-volume cleanup; CI will exercise the same path).

Note: only the historical comment reference in `reference/compose/compose.yaml` survives (intentional — it documents the prior removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)