### PR TITLE
Fix #118: setup-experiment bootstrap_curl cwd

### DIFF
--- a/reference/scripts/setup-experiment/setup-experiment.sh
+++ b/reference/scripts/setup-experiment/setup-experiment.sh
@@ -545,20 +545,20 @@ echo "--- bringing up forgejo synchronously ---" >&2
 # non-zero if the user exists; the change-password fallback handles
 # the re-run case.
 echo "--- provisioning forgejo eden user ---" >&2
-if ! docker compose -f "${COMPOSE_DIR}/compose.yaml" --env-file "$ENV_FILE" \
+if ! (cd "$COMPOSE_DIR" && docker compose --env-file "$ENV_FILE" \
         exec -T forgejo forgejo admin user create \
             --username eden \
             --password "$FORGEJO_REMOTE_PASSWORD" \
             --email eden@invalid \
             --admin \
-            --must-change-password=false \
+            --must-change-password=false) \
         >&2 2>&1
 then
-    docker compose -f "${COMPOSE_DIR}/compose.yaml" --env-file "$ENV_FILE" \
+    (cd "$COMPOSE_DIR" && docker compose --env-file "$ENV_FILE" \
         exec -T forgejo forgejo admin user change-password \
             --username eden \
             --password "$FORGEJO_REMOTE_PASSWORD" \
-            --must-change-password=false >&2
+            --must-change-password=false) >&2
 fi
 
 echo "--- creating forgejo repo eden/${EXPERIMENT_ID} ---" >&2
@@ -694,8 +694,8 @@ bootstrap_curl() {
         args+=(-d "$body")
     fi
     args+=("http://localhost:8080${path}")
-    docker compose -f compose.yaml --env-file "$ENV_FILE" \
-        exec -T task-store-server curl "${args[@]}" || true
+    (cd "$COMPOSE_DIR" && docker compose --env-file "$ENV_FILE" \
+        exec -T task-store-server curl "${args[@]}") || true
 }
 
 echo "--- registering reserved groups + initial admin worker ---" >&2


### PR DESCRIPTION
Closes #118.

`bootstrap_curl` in `reference/scripts/setup-experiment/setup-experiment.sh` called `docker compose -f compose.yaml --env-file "$ENV_FILE" exec -T task-store-server curl …` without first `cd`-ing into `$COMPOSE_DIR`. Since `-f compose.yaml` is a relative path, invoking setup-experiment from outside `reference/compose/` (e.g. via the `eden-experiment` wrapper, or from `/tmp`) failed with `open <CWD>/compose.yaml: no such file or directory`.

## Fix

Wrap the bootstrap_curl invocation in the same `(cd "$COMPOSE_DIR" && docker compose --env-file "$ENV_FILE" …)` pattern used by every other compose call in the script.

While auditing the script for the same shape, the two forgejo admin user calls (create / change-password) used absolute `-f "${COMPOSE_DIR}/compose.yaml"` — these worked but were inconsistent with the established pattern. Converted both for consistency in the same commit.

## Verification

- `cd /tmp && bash …/setup-experiment.sh …/config.yaml --experiment-id test-118` — completes cleanly through bootstrap (was failing at `bootstrap_curl` before).
- `bash reference/compose/healthcheck/smoke.sh` — PASS.

## Test plan

- [x] setup-experiment from outside `reference/compose/` completes
- [x] Compose smoke (`smoke.sh`) passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)