### PR TITLE
Fix #129: forgejo bind-mount targets /var/lib/gitea (not /var/lib/forgejo)

### DIFF
--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -40,7 +40,7 @@ services:
       FORGEJO__server__SSH_PORT: "${FORGEJO_SSH_HOST_PORT:-2222}"
       FORGEJO__server__SSH_LISTEN_PORT: "2222"
       FORGEJO__database__DB_TYPE: sqlite3
-      FORGEJO__database__PATH: /var/lib/forgejo/data/forgejo.db
+      FORGEJO__database__PATH: /var/lib/gitea/data/forgejo.db
       FORGEJO__security__INSTALL_LOCK: "true"
       FORGEJO__security__SECRET_KEY: ${FORGEJO_SECRET_KEY:?FORGEJO_SECRET_KEY must be set}
       FORGEJO__security__INTERNAL_TOKEN: ${FORGEJO_INTERNAL_TOKEN:?FORGEJO_INTERNAL_TOKEN must be set}
@@ -52,7 +52,7 @@ services:
       - "${FORGEJO_SSH_HOST_PORT:-2222}:2222"
     volumes:
       # Durable substrate (Phase 12a-1g) — see postgres above.
-      - ${EDEN_EXPERIMENT_DATA_ROOT:?EDEN_EXPERIMENT_DATA_ROOT must be set (run setup-experiment)}/forgejo:/var/lib/forgejo
+      - ${EDEN_EXPERIMENT_DATA_ROOT:?EDEN_EXPERIMENT_DATA_ROOT must be set (run setup-experiment)}/forgejo:/var/lib/gitea
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/v1/version"]
       interval: 5s

--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -40,6 +40,10 @@ services:
       FORGEJO__server__SSH_PORT: "${FORGEJO_SSH_HOST_PORT:-2222}"
       FORGEJO__server__SSH_LISTEN_PORT: "2222"
       FORGEJO__database__DB_TYPE: sqlite3
+      # NOTE: container-internal path stays `/var/lib/gitea/` — see the
+      # volume mount below for the rationale (upstream image VOLUME
+      # declarations retain Gitea's legacy paths; do not rename to
+      # match the Forgejo brand surface, see issue #129).
       FORGEJO__database__PATH: /var/lib/gitea/data/forgejo.db
       FORGEJO__security__INSTALL_LOCK: "true"
       FORGEJO__security__SECRET_KEY: ${FORGEJO_SECRET_KEY:?FORGEJO_SECRET_KEY must be set}
@@ -52,6 +56,22 @@ services:
       - "${FORGEJO_SSH_HOST_PORT:-2222}:2222"
     volumes:
       # Durable substrate (Phase 12a-1g) — see postgres above.
+      #
+      # The container target is `/var/lib/gitea`, NOT `/var/lib/forgejo`,
+      # despite this being the Forgejo image. This is intentional:
+      # the Forgejo image is a soft fork of Gitea and its Dockerfile
+      # declares `VOLUME ["/etc/gitea", "/var/lib/gitea"]` to preserve
+      # migration compatibility from Gitea deployments. Forgejo
+      # writes its data to `/var/lib/gitea/` regardless of the brand;
+      # binding a different container path (e.g. `/var/lib/forgejo`)
+      # leaves the actual data path backed by an anonymous Docker
+      # volume that does NOT survive Docker Desktop VM restarts or
+      # `docker volume prune`, silently breaking the 12a-1g durability
+      # contract. See issue #129 for the bug history.
+      #
+      # The host-side path (`$EDEN_EXPERIMENT_DATA_ROOT/forgejo`) is
+      # under our control and uses the Forgejo brand name. The
+      # container target is image-defined; do not rename it.
       - ${EDEN_EXPERIMENT_DATA_ROOT:?EDEN_EXPERIMENT_DATA_ROOT must be set (run setup-experiment)}/forgejo:/var/lib/gitea
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/v1/version"]


### PR DESCRIPTION
Closes #129.

Cherry-picked from `demo/operator-exploration` (commits `57755d4` + `89cb328`).

PR #113 (Gitea → Forgejo migration) treated the compose bind-mount target path as part of the Gitea→Forgejo rename and changed it from `/var/lib/gitea` to `/var/lib/forgejo`. But that container-internal path is a property of the **image**, not the branded service name: the Forgejo image (codeberg.org/forgejo/forgejo:11-rootless) inherits Gitea's legacy layout. Its `Config.Volumes` declares `/etc/gitea` and `/var/lib/gitea` — there is no `/var/lib/forgejo`.

**Effect of the bug:** the host bind-mount at `$EDEN_EXPERIMENT_DATA_ROOT/forgejo` was targeting an unused directory inside the container, while Forgejo's actual data path (`/var/lib/gitea`) was backed by an anonymous Docker volume that gets dropped on Docker Desktop VM restart. Substrate durability was silently broken.

Follow-up issue #130 covers also bind-mounting `/etc/gitea` for full config durability.

Verified locally by the operator during demo session.