### PR TITLE
Land demo-session residual: PRD draft, observability guide, log retention + control-plane overlay

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,314 @@
+# EDEN observability guide
+
+> **Last verified against commit `ff3d4a9` (Phase 12c).** Companion to [`docs/user-guide.md`](user-guide.md). EDEN moves fast — if a route, schema, or port doesn't match what you see, trust the code.
+
+This guide enumerates every place you can look at live state in an EDEN deployment: the first-party surfaces that ship with the Compose stack, and the third-party admin UIs you can attach to the same network for deeper introspection. It assumes you already have a stack up per [`user-guide.md` §2](user-guide.md#2-workflow-0-setting-up-an-experiment).
+
+For the model — what tasks / ideas / variants / events / claims are — see [`glossary.md`](glossary.md).
+
+## Contents
+
+1. [What "observability" means here](#1-what-observability-means-here)
+2. [First-party surfaces](#2-first-party-surfaces)
+3. [Bring-your-own admin UIs](#3-bring-your-own-admin-uis)
+4. [Following a variant end-to-end](#4-following-a-variant-end-to-end)
+5. [Alternatives and informational notes](#5-alternatives-and-informational-notes)
+
+## 1. What "observability" means here
+
+EDEN's state lives in four substrates:
+
+| Substrate | What's in it | How it's persisted |
+|---|---|---|
+| **Task store** (Postgres) | Tasks, ideas, variants, submissions, events, workers, groups, dispatch decisions, leases, experiment state | Host bind-mount at `${EDEN_EXPERIMENT_DATA_ROOT}/postgres/` (12a-1g) |
+| **Git remote** (Forgejo) | The experiment repo: seed commit + `work/*` (executor scratch) + `variant/*` (integrated lineage) + `main` | Host bind-mount at `${EDEN_EXPERIMENT_DATA_ROOT}/forgejo/` |
+| **Artifacts** | Worker-emitted blobs: idea content, evaluation outputs | Host bind-mount at `${EDEN_EXPERIMENT_DATA_ROOT}/artifacts/` ⇄ `/var/lib/eden/artifacts/` inside web-ui; served at `GET /artifacts?uri=file://...` (session-authed). **Empty in scripted mode** — only subprocess mode writes real files. |
+| **Process logs** | Container stdout from each service | Captured by Docker's logging driver; ephemeral |
+
+Every observability tool below reads from one or more of these. The event log in the task store is the closest thing to a single source of truth — every state change of consequence emits an event, and the orchestrator's loop is driven entirely by reads against it.
+
+## 2. First-party surfaces
+
+These ship with the Compose stack. No extra setup beyond `setup-experiment.sh` + `compose up`.
+
+### 2.1 Web UI admin dashboards (`http://localhost:8090/admin/*`)
+
+Sign in with principal `admin`, secret from `EDEN_ADMIN_TOKEN` in `.env`.
+
+| Route | Shows |
+|---|---|
+| `/admin/` | Index of the dashboards below |
+| `/admin/tasks/` | All tasks, filterable by `kind` + `state`; claim-age + claim-expired badges |
+| `/admin/tasks/<id>/` | Per-task detail: full payload, claim status, lineage chain, reassign + reclaim forms |
+| `/admin/ideas/` | All ideas, with inline content preview |
+| `/admin/ideas/<id>/` | Per-idea detail; admin "Create execution task" form (12a-3) |
+| `/admin/variants/` | All variants, filterable by `status`; orphaned-starting badge |
+| `/admin/variants/<id>/` | Per-variant detail: lineage + related-events filter |
+| `/admin/events/` | Event log with limit + reverse + filter; stable indexing across filter operations |
+| `/admin/workers/` | Worker registry; register + reissue-credential forms |
+| `/admin/groups/` | Group registry; add / remove / delete; reserved-id rejection |
+| `/admin/work-refs/` | `refs/heads/work/*` branches classified by status; CAS-guarded deletion (requires web-ui started with `--repo-path`) |
+| `/admin/experiment/` | Experiment state (`running` / `terminated`); terminate form (12a-3) |
+| `/admin/dispatch-mode/` | Per-decision-type dispatch mode toggle: auto vs manual (12a-2) |
+| `/admin/experiments/` | Multi-experiment registry; register / select / unregister (12c). **Gated on `--control-plane-url`** — see below |
+
+Notes:
+
+- These are read views over the wire API. Filter changes do not mutate state.
+- Reclaim / reassign / terminate / dispatch-mode toggles do mutate, behind CSRF + the same authorization model as the wire API.
+- `/admin/experiments/` is only mounted when the web-ui is started with `--control-plane-url`. The default Compose stack omits this flag; the route returns 404 ("page does not exist") until a control-plane-server is wired up. To enable it on the demo stack, run a sibling control-plane container and recreate the web-ui with the [`compose.control-plane.yaml`](../reference/compose/compose.control-plane.yaml) overlay — see [§3.4](#34-enabling-the-multi-experiment-control-plane).
+
+### 2.2 Forgejo Web UI (`http://localhost:3001`)
+
+Sign in as user `eden`, password from `FORGEJO_REMOTE_PASSWORD` in `.env`.
+
+Useful for: browsing branches (`work/*`, `variant/*`, `main`), diffing arbitrary commits, inspecting the `.eden/variants/<id>/evaluation.json` manifests the integrator writes onto the canonical `variant/*` lineage.
+
+### 2.3 Artifacts
+
+Worker-emitted artifacts (idea content markdown, evaluation outputs) live under `${EDEN_EXPERIMENT_DATA_ROOT}/artifacts/` on the host. That directory is the same bind-mount the web-ui sees as `/var/lib/eden/artifacts/` — host path and container path are two views of the same bytes.
+
+**Important caveat — scripted mode produces no artifact files.** The default Compose deployment runs the worker hosts in **scripted** mode; the scripted ideator / executor / evaluator stamp `artifacts_uri = file:///tmp/artifacts/...` onto every submission but never write those files to disk. The strings are fictional pointers. To see real artifact files in this directory, run [subprocess mode](user-guide.md#3-worker-host-modes) (`-f compose.yaml -f compose.subprocess.yaml`) — only then do the user-supplied `*_command` workers emit real bytes under `/var/lib/eden/artifacts/`.
+
+Three ways to read artifacts when they exist:
+
+```bash
+# 1. Direct host read:
+ls "$(sed -n 's/^EDEN_EXPERIMENT_DATA_ROOT=//p' reference/compose/.env)/artifacts/"
+
+# 2. Inside the web-ui container (same bytes, different view):
+docker exec eden-web-ui ls /var/lib/eden/artifacts/
+
+# 3. Through the web-ui's /artifacts route (session-authed via the
+#    sign-in cookie, NOT bearer-authed):
+#    Sign in to http://localhost:8090, then in the same browser session:
+#    http://localhost:8090/artifacts?uri=file:///var/lib/eden/artifacts/<file>
+#    Path-traversal outside /var/lib/eden/artifacts returns 404.
+```
+
+The web-ui's executor / evaluator forms inline artifacts for you automatically when the URI resolves under the `--artifacts-dir` bind. There is no `/_reference/` prefix; there is no directory-listing endpoint — only the `?uri=...` lookup form.
+
+### 2.4 Wire API (raw)
+
+The task-store-server speaks JSON over HTTP. Every state-mutating operation in EDEN lives here. Convenient one-liners:
+
+```bash
+ADMIN=$(grep '^EDEN_ADMIN_TOKEN=' reference/compose/.env | cut -d= -f2)
+EXPERIMENT_ID=demo-phase12
+H=(-H "Authorization: Bearer admin:$ADMIN" -H "X-Eden-Experiment-Id: $EXPERIMENT_ID")
+BASE="http://localhost:8080/v0/experiments/$EXPERIMENT_ID"
+
+curl -s "${H[@]}" "$BASE/tasks"           | jq
+curl -s "${H[@]}" "$BASE/ideas"           | jq
+curl -s "${H[@]}" "$BASE/variants"        | jq
+curl -s "${H[@]}" "$BASE/events?cursor=0" | jq '.events[].type' | tail -30
+curl -s "${H[@]}" "$BASE/workers"         | jq
+```
+
+FastAPI's `/docs`, `/openapi.json`, and `/redoc` are mounted on the task-store-server but auth-gated. For a browsable spec, see [§3.2](#32-swagger-ui-for-the-wire-api).
+
+### 2.5 Container logs
+
+```bash
+cd reference/compose
+docker compose --env-file .env ps                    # service health snapshot
+docker compose --env-file .env logs -f orchestrator  # tail one service
+docker compose --env-file .env logs --since 5m       # all services, last 5 min
+```
+
+The orchestrator's log is the highest-signal one for "what is the system doing right now" — every dispatch decision is logged with a `decision_type` + `outcome`.
+
+**Log retention.** Each service's docker logging driver is set to `json-file` with `max-size: 50m` and `max-file: 5` — roughly 250MB per service before rotation. This is enough for a multi-hour debugging window. The hard limits today:
+
+- **`docker compose stop`** preserves logs (the container is retained, only the process exits).
+- **`docker compose down`** removes containers and **deletes** their logs.
+- A SIGKILL'd container may lose the last in-flight stdout write; Python's logging module flushes on signal, so the practical risk is small but not zero.
+
+The four-rung ladder for production-grade persistence — only **L1** is in place today:
+
+| Rung | What it gives you | Status |
+|---|---|---|
+| **L1** | Bumped docker rotation (50MB × 5 per service) | In place — applies on next container recreate |
+| **L2** | Per-service file handler writing to `${EDEN_EXPERIMENT_DATA_ROOT}/logs/` (bind-mount; survives `compose down -v`) | Tracked in [#109](https://github.com/ealt/eden/issues/109) |
+| **L3** | In-stack search UI (Loki + Promtail + Grafana overlay at `localhost:3000`) | Tracked in [#110](https://github.com/ealt/eden/issues/110) |
+| **L4** | External streaming to CloudWatch / Datadog / Grafana Cloud / etc. | Production-grade; out of scope for the reference stack — wire each service's stdout to your collector of choice |
+
+### 2.6 Read-only local clone of Forgejo
+
+For deeper git introspection (`git log --graph`, `git diff` between arbitrary refs, scripted traversal), clone the Forgejo remote locally and never push:
+
+```bash
+PASS=$(grep '^FORGEJO_REMOTE_PASSWORD=' reference/compose/.env | cut -d= -f2)
+git clone "http://eden:${PASS}@localhost:3001/eden/<experiment-id>.git" /tmp/eden-readonly
+cd /tmp/eden-readonly
+git log --all --decorate --oneline --graph
+```
+
+Refresh with `git fetch --all --prune`. The Forgejo Web UI (§2.2 above) covers casual browsing; a local clone wins for batch / scripted inspection.
+
+### 2.7 The readonly Postgres role
+
+The task-store-server provisions an `eden_readonly` SQL role at startup, gated by `EDEN_READONLY_PASSWORD` in `.env`. It has `SELECT` on the event log, tasks, ideas, variants, submissions, workers (column-restricted; no credential hashes), groups, and migration bookkeeping. Schema reference: [`docs/operations/agent-readonly-db.md`](operations/agent-readonly-db.md).
+
+Connect with `psql`:
+
+```bash
+PG_PASS=$(grep '^EDEN_READONLY_PASSWORD=' reference/compose/.env | cut -d= -f2)
+PGPASSWORD="$PG_PASS" psql -h localhost -p 5433 -U eden_readonly -d eden
+```
+
+Or attach a browser via Adminer — see [§3.1](#31-adminer-for-postgres).
+
+## 3. Bring-your-own admin UIs
+
+These do not ship with the Compose stack. They're one-shot `docker run` siblings on the same docker network. Useful for ad-hoc inspection; tear them down when you're done.
+
+### 3.1 Adminer for Postgres
+
+```bash
+docker run --rm -d --name eden-demo-adminer \
+  --network eden-reference_default \
+  -p 8091:8080 \
+  adminer:4
+```
+
+Open `http://localhost:8091`. Connect as:
+
+- **System**: PostgreSQL
+- **Server**: `postgres` (the in-network container name)
+- **Username**: `eden_readonly` (safer than the superuser) or `eden` (write access)
+- **Password**: `EDEN_READONLY_PASSWORD` or `POSTGRES_PASSWORD` from `.env`
+- **Database**: `eden`
+
+Useful queries against the readonly role: see [`agent-readonly-db.md` §3](operations/agent-readonly-db.md). The schema is byte-for-byte parallel to SQLite — JSON blobs in a `data` text column rather than typed `jsonb`, so query the structure with `data::jsonb ->> 'field'`.
+
+Tear down: `docker rm -f eden-demo-adminer`.
+
+### 3.2 Swagger UI for the wire API
+
+The task-store-server's OpenAPI spec is auth-gated, so we snapshot it once and serve it from a separate container.
+
+```bash
+ADMIN=$(grep '^EDEN_ADMIN_TOKEN=' reference/compose/.env | cut -d= -f2)
+mkdir -p /tmp/eden-demo-swagger
+curl -s -H "Authorization: Bearer admin:$ADMIN" \
+  http://localhost:8080/openapi.json -o /tmp/eden-demo-swagger/openapi.json
+
+docker run --rm -d --name eden-demo-swagger \
+  -p 8092:8080 \
+  -v /tmp/eden-demo-swagger/openapi.json:/openapi.json:ro \
+  -e SWAGGER_JSON=/openapi.json \
+  swaggerapi/swagger-ui
+```
+
+Open `http://localhost:8092`. Browsing the spec works without auth.
+
+**"Try it out" caveat:** Swagger UI sends real requests to `http://localhost:8080`, which is bearer-gated. The OpenAPI spec doesn't declare a `securitySchemes` block, so the Authorize button isn't useful. Two workarounds:
+
+- Copy the curl command Swagger generates and add `-H "Authorization: Bearer admin:<TOKEN>"` yourself.
+- Use a browser extension (ModHeader, Requestly) to inject the header for `localhost:8080` requests.
+
+Re-snapshot the spec after any code change touching wire endpoints.
+
+Tear down: `docker rm -f eden-demo-swagger`.
+
+### 3.3 Desktop database clients
+
+If you prefer a desktop tool over Adminer, connect directly to `localhost:5433` with `eden_readonly` / `EDEN_READONLY_PASSWORD`. Tested combinations:
+
+- TablePlus, DBeaver, Postico, DataGrip — all work standard PostgreSQL connections.
+- pgAdmin — works but feels heavy for a single experiment; better suited to multi-cluster environments.
+
+### 3.4 Enabling the multi-experiment control plane
+
+The `/admin/experiments/` route is gated on the web-ui being started with `--control-plane-url`. Phase 12c shipped the control-plane-server as a separate service that the default Compose stack does not start. To enable the route on a running demo stack:
+
+```bash
+# 1. Spin up control-plane-server as a sibling container on the eden network.
+ADMIN=$(grep '^EDEN_ADMIN_TOKEN=' reference/compose/.env | cut -d= -f2)
+docker run --rm -d --name eden-demo-control-plane \
+  --network eden-reference_default \
+  -p 8081:8081 \
+  eden-reference:dev \
+  python -m eden_control_plane_server \
+    --store-url ':memory:' \
+    --host 0.0.0.0 --port 8081 \
+    --admin-token "$ADMIN" \
+    --task-store-url http://task-store-server:8080
+
+# 2. Tell the web-ui's overlay where to find it, then recreate web-ui only.
+cd reference/compose
+echo 'EDEN_CONTROL_PLANE_URL=http://eden-demo-control-plane:8081' >> .env
+docker compose --env-file .env \
+  -f compose.yaml -f compose.control-plane.yaml \
+  up -d --force-recreate --no-deps web-ui
+```
+
+`compose.control-plane.yaml` is an overlay that re-declares the web-ui's `command:` with the two extra flags (`--control-plane-url` + `--control-plane-admin-token`). Compose replaces (not merges) list-shaped command keys, so the overlay carries the full command — keep it in lockstep with `compose.yaml` if web-ui flags change.
+
+`/admin/experiments/` now resolves (303 → sign-in if you're not authenticated, 200 once you are). The control-plane API itself listens at `http://localhost:8081/v0/control/*` (14 endpoints; bearer-authed with the same admin token); fetch its `/openapi.json` with the bearer for the full surface.
+
+State-sync caveat: the demo command above uses `:memory:` storage, so the control-plane forgets its experiment registry on container restart. For a persistent deployment you'd point `--store-url` at Postgres (a separate database / schema from the task store), and likely run it as a first-class Compose service rather than a sibling container.
+
+Tear down:
+
+```bash
+docker rm -f eden-demo-control-plane
+# Optional: revert the web-ui to the no-control-plane command.
+cd reference/compose
+sed -i.bak '/^EDEN_CONTROL_PLANE_URL=/d' .env && rm .env.bak
+docker compose --env-file .env up -d --force-recreate --no-deps web-ui
+```
+
+### 3.5 Desktop HTTP clients
+
+For richer API exploration than curl + Swagger:
+
+- Postman, Insomnia, Bruno — import the OpenAPI spec from `/tmp/eden-demo-swagger/openapi.json` (Postman: File → Import → openapi.json). Set a collection-level bearer of `admin:<token>` and the auth-gated endpoints become clickable.
+
+## 4. Following a variant end-to-end
+
+A worked example: trace variant `v-abc123` from idea to integration.
+
+1. **Find the idea** that spawned the execution task:
+   - Web UI: `/admin/variants/v-abc123/` → click into "lineage".
+   - SQL: `SELECT data FROM idea WHERE idea_id = (SELECT data::jsonb ->> 'idea_id' FROM variant WHERE variant_id = 'v-abc123');`
+2. **See the execution work** on Forgejo: `http://localhost:3001/eden/<experiment-id>/src/branch/work/<slug>-v-abc123` — every intermediate commit the executor made.
+3. **See the integrated lineage**: `http://localhost:3001/eden/<experiment-id>/src/branch/variant/v-abc123-<slug>` — the squashed single commit + `.eden/variants/v-abc123/evaluation.json`.
+4. **Read the evaluation submission**: `/admin/events/?filter=variant.succeeded&q=v-abc123` (web UI) or `SELECT data FROM submission WHERE data::jsonb ->> 'variant_id' = 'v-abc123';` (SQL).
+5. **See every event mentioning this variant** in order:
+
+   ```sql
+   SELECT seq, type, occurred_at FROM event
+   WHERE data::jsonb ->> 'variant_id' = 'v-abc123'
+   ORDER BY seq;
+   ```
+
+   The orchestrator's loop never has access to anything you can't reproduce from this stream.
+
+## 5. Alternatives and informational notes
+
+### Forgejo (and Gitea)
+
+The reference stack runs Forgejo (`codeberg.org/forgejo/forgejo:11-rootless`) as of PR #113 — switched from upstream Gitea since the two are API + UI source-compatible for the features EDEN uses (private repos, HTTP-Basic auth, repo-create API, push) and Forgejo has the more active maintenance posture post the 2022 governance fork. Swapping back to Gitea is a one-line image change in `compose.yaml` and would work unchanged for the EDEN use case; no reason to do so unless you have an operational requirement.
+
+### Other git-storage substrates
+
+The Forgejo container is acting as a per-experiment private HTTP-Basic-authenticated git remote. Anything that satisfies that interface is a candidate replacement. The integrator's contract is just "push `variant/*` refs, read them back" — it does not depend on any Forgejo-specific feature.
+
+If you're evaluating alternatives, the relevant questions are: does it support HTTP-Basic auth for cloning + pushing; does it expose a repo-creation API; does it survive container restart. We don't ship any other substrate in the reference stack today.
+
+### pgAdmin vs Adminer
+
+Adminer is a single-file PHP app — small image, quick to spin up, fine for a single experiment. pgAdmin is heavier (Python + a queryable internal store) but more capable: query history, ER diagrams, server groups. For one-shot demo inspection, Adminer wins; for multi-cluster operational work, pgAdmin is worth the weight.
+
+### Teardown
+
+When you're done with the bring-your-own tools:
+
+```bash
+docker rm -f eden-demo-adminer eden-demo-swagger
+rm -rf /tmp/eden-demo-swagger
+```
+
+These run outside Compose, so a `compose down` does not touch them.

--- a/docs/prds/eden-experiment-platform.md
+++ b/docs/prds/eden-experiment-platform.md
@@ -1,0 +1,147 @@
+# PRD: EDEN as an experiment platform
+
+> **Status: draft (2026-05-21).** This document captures the long-horizon vision for how EDEN should be deployed and operated at scale. It is not yet an executable plan; see [`docs/plans/`](../plans/) and the linked GitHub issues for the work along the way.
+
+## 1. Vision
+
+Teams operating EDEN should interact with **one server** to create, run, and manage experiments — regardless of how distributed the underlying infrastructure is. The operator submits an experiment config; a centralized controller decides which substrates host the experiment (which Postgres holds the task store, which Forgejo holds the repo, which object store holds artifacts, which compute fleet runs the workers) and binds them together. The operator never needs to know where any of those pieces live.
+
+The same controller abstraction has to work for two extremes of deployment shape without changing the operator-facing interface:
+
+- **Laptop:** every substrate is a Compose-managed container on `localhost`. The controller binds them.
+- **Cluster:** substrates are spread across managed services (RDS, S3, hardened Forgejo on a separate host) and k8s nodes. The controller binds them.
+
+Same API, same `start-experiment` call, same configuration shape. The substrate adapter underneath changes; the operator's mental model does not.
+
+## 2. What's broken today
+
+The reference deployment conflates **provisioning infrastructure** with **running an experiment**:
+
+- `setup-experiment.sh` provisions a fresh Postgres + Forgejo per experiment.
+- Each experiment runs its own task-store-server, orchestrator, and worker hosts, locked to one experiment via startup flags.
+- Running N experiments side-by-side means N copies of every substrate, even though substrates can structurally host N experiments (Postgres has databases, Forgejo has repos).
+- There is no concept of "infrastructure exists; let me add an experiment to it." Every experiment is a fresh stack.
+
+Phase 12c shipped a control-plane-server that is the first step toward a centralized controller — but it is a metadata registry + lease coordinator. It does **not** know about the substrates, allocate them, or stand experiments up. It tracks experiments that the operator stood up by other means.
+
+## 3. What the controller is responsible for
+
+The platform controller is:
+
+- **A substrate inventory.** Adapters (Postgres provider, git remote provider, object store provider, compute provider, …) register themselves with the controller at deployment time. Each adapter describes what it can host and how to provision a tenant within it.
+- **A scheduler.** When an operator submits an experiment config, the controller picks substrates from inventory, asks each one to create the experiment's namespace (database / repo / bucket / pod), and records the bindings.
+- **A registry.** The controller is the source of truth for "which experiments exist, where they live, what state they're in." Operators querying the registry get a stable view independent of substrate failures.
+- **A lifecycle manager.** Start / end an experiment without touching other experiments or the substrate layer beneath. Provision / tear down substrate adapters without breaking running experiments.
+- **A single endpoint for operators.** Everything an operator does — register an experiment, view its state, terminate it, view its history, list experiments — flows through one well-known URL.
+
+The controller is **not** responsible for:
+
+- Running the task-store / orchestrator / worker logic itself. Those are separate services that the controller allocates and starts.
+- Storing protocol state. The task-store-server still owns events, tasks, ideas, variants.
+- Authenticating end users. Auth flows through the deployment-level admin identity layer (existing chapter 7 §13).
+
+## 4. Substrate inventory model
+
+A **substrate adapter** is a piece of code that implements a small interface:
+
+- `register(controller, config)` — announce capability to the controller at startup. The adapter describes its kind (`postgres` / `git-remote` / `object-store` / `compute`), capacity, and the connection details needed to provision tenants.
+- `provision(experiment_id, spec)` — allocate a namespace for the experiment. Postgres adapter creates a database or schema; git-remote adapter creates a repo; object-store adapter creates a bucket prefix; compute adapter allocates pods or Compose services.
+- `release(experiment_id)` — deallocate the namespace.
+- `health()` — substrate readiness probe.
+
+The controller keeps an `(adapter_kind, adapter_id, capacity)` table. When an operator submits an experiment, the controller chooses one adapter per required kind, calls `provision` on each, records the bindings, and exposes the resulting substrate endpoints (task-store URL, git remote URL, artifacts URL, …) to the experiment's services.
+
+Adapters are pluggable. A laptop deployment registers one Compose-Postgres adapter, one Compose-Forgejo adapter, one Compose-MinIO adapter. A cluster deployment registers one RDS adapter, one hardened-Forgejo adapter, one S3 adapter. Same controller code; different adapter registrations.
+
+## 5. Operator lifecycle on the platform
+
+The platform replaces today's single conflated `setup-experiment.sh` with a four-step ladder:
+
+| Step | Today | After |
+|---|---|---|
+| **1. Provision infra** | Conflated with step 2 | Operator runs the laptop or cluster provisioner once. Substrate adapters come up and register with the controller. |
+| **2. Start an experiment** | `setup-experiment.sh <config> --experiment-id <id>` provisions everything | `POST /v0/control/experiments` with the config. Controller picks substrates, provisions namespaces, brings up per-experiment services, returns the experiment's endpoint. |
+| **3. End an experiment** | No equivalent — only "teardown everything" | `DELETE /v0/control/experiments/<id>`. Controller asks each bound substrate to release its namespace, tears down per-experiment services. Other experiments are unaffected. |
+| **4. Teardown infra** | `compose down -v` + `rm -rf $DATA_ROOT` | Tear down substrate adapters. Refuses to run if registered experiments still exist. |
+
+Critical invariants:
+
+- Step 1 is independent of any experiment. Run once per workstation or cluster.
+- Step 3 leaves the substrate layer intact for other experiments.
+- Step 4 is reserved for actually decommissioning the machine.
+
+## 6. Laptop ↔ cluster portability
+
+The portability requirement is **load-bearing**: an EDEN deployment must be runnable end-to-end on one laptop without changing the operator-facing interface. This constrains the platform design in several ways:
+
+- **No assumption of always-on managed services.** A laptop deployment uses Compose-hosted substrate adapters; the controller treats them identically to managed-service adapters.
+- **No assumption of always-on network.** Adapter health probes have to handle local-process failures gracefully (a Compose container restart) the same way they handle managed-service failures.
+- **No external auth dependency for the base case.** The laptop deployment's controller authenticates substrates via local secrets (admin tokens generated by the provisioner); the cluster deployment can layer IAM / OAuth / SSO on top without changing the controller's wire surface.
+- **Config-driven substrate selection.** The controller picks the laptop substrate when the laptop adapter is the only one of its kind registered; it picks the cluster substrate when the cluster adapter is the only one. Heterogeneous deployments (laptop adapter + cluster adapter both registered) are a future scheduling concern.
+
+A laptop user runs:
+
+```bash
+provision-infra.sh --target laptop      # Brings up Compose substrate adapters
+                                         # + controller. Idempotent.
+start-experiment.sh my-config.yaml       # Talks only to the controller.
+                                         # Operator does not know Postgres exists.
+```
+
+A cluster operator runs:
+
+```bash
+provision-infra.sh --target cluster --postgres-endpoint rds.example.com \
+                                    --forgejo-endpoint forgejo.example.com \
+                                    --object-store s3://eden-prod/
+start-experiment.sh my-config.yaml
+```
+
+Same `start-experiment.sh`. Same controller endpoint.
+
+## 7. Non-goals
+
+- **Multi-tenant auth between teams.** Today the deployment admin is one identity. Cross-team isolation, RBAC at the experiment level, and audit trails per-team are out of scope for this PRD. Layer on top.
+- **Heterogeneous substrate scheduling.** When multiple Postgres adapters are registered with different capacities / latencies / costs, choosing which one to assign an experiment to is a scheduling problem we are not solving here. The first cut picks arbitrarily.
+- **Substrate migration.** Once an experiment is bound to a Postgres, it stays there. Moving an experiment's substrate bindings during its lifetime is out of scope.
+- **Cross-controller federation.** One deployment, one controller. Multi-region / multi-controller is a future concern.
+- **Spot / preemptible compute.** Compute adapters that can revoke worker pods at runtime require the protocol to handle worker eviction gracefully; this is orthogonal and worth its own design.
+
+## 8. Open questions
+
+- **Controller auth to substrates.** Does the controller hold long-lived credentials for each substrate, or short-lived tokens minted per provisioning request? Trade-off: blast radius if controller is compromised vs. complexity of token rotation.
+- **Substrate adapter failure model.** When an adapter's `provision` call fails halfway through (database created, repo creation failed), how does the controller roll back? Two-phase commit across heterogeneous substrates is hard; the alternative is idempotent provision + a reconciliation loop.
+- **Controller HA.** Today's control-plane-server is single-process. A real platform controller needs N-replica HA. Does the lease primitive from chapter 11 generalize, or do we need something fully consensus-backed (Raft / etcd / managed equivalent)?
+- **Substrate adapter API surface.** Is the `register / provision / release / health` interface enough, or do we need richer queries (capacity, current usage, latency)? Schema evolution as new substrate kinds emerge.
+- **Experiment config schema evolution.** When the controller's understanding of a config field changes, what does it do with already-running experiments? Pinned-by-version configs vs. live-migration semantics.
+- **State sync between substrate and registry.** Today the chapter 11 §3 state-sync poller mirrors per-experiment state from the task-store. With substrates registered with the controller, more state needs syncing (substrate health, capacity utilization). What's the poller's contract under this expansion?
+
+## 9. Implementation stepping stones
+
+The platform vision lands incrementally. Each step delivers operator-visible value on its own.
+
+| Step | What | Issue |
+|---|---|---|
+| 1 | Share Postgres + Forgejo substrates across experiments in the reference Compose stack | (to be filed alongside this PRD) |
+| 2 | Lift task-store-server from single-experiment to N-experiment dispatch | (to be filed) |
+| 3 | Make the orchestrator a persistent multi-experiment service | (to be filed) |
+| 4 | Web UI deployment-level base page + experiment-scoped after selection | (to be filed) |
+| 5 | Phase 13 substrate adapters (managed Postgres, S3/GCS blob, hardened Forgejo, k8s compute) | [`docs/plans/eden-phase-13a-helm-base-chart.md`](../plans/eden-phase-13a-helm-base-chart.md) + sibling phase-13 plans |
+| 6 | Substrate-adapter abstraction layer in the controller | Future |
+| 7 | Single `POST /v0/control/experiments` end-to-end provisioning | Future |
+| 8 | Substrate inventory + scheduling | Future |
+
+Steps 1–4 are the multi-experiment runtime work — necessary precursors. Step 5 is Phase 13 (already partially planned). Steps 6–8 are the platform synthesis on top of those foundations.
+
+The PRD should be re-reviewed at each step to refine the open questions and possibly split into multiple PRDs as the design surfaces become real.
+
+## 10. References
+
+- [`docs/roadmap.md`](../roadmap.md) — the 13-phase build-up
+- [`docs/plans/eden-phase-12c-control-plane.md`](../plans/eden-phase-12c-control-plane.md) — control plane as currently shipped
+- [`docs/plans/eden-phase-13a-helm-base-chart.md`](../plans/eden-phase-13a-helm-base-chart.md) — Helm chart (k8s deployment shape)
+- [`docs/plans/eden-phase-13c-managed-postgres.md`](../plans/eden-phase-13c-managed-postgres.md) — managed Postgres adapter
+- [`docs/plans/eden-phase-13d-blob-backend.md`](../plans/eden-phase-13d-blob-backend.md) — S3/GCS object store adapter
+- [`docs/plans/eden-phase-13e-gitea-hardening.md`](../plans/eden-phase-13e-gitea-hardening.md) — hardened git remote adapter
+- [`spec/v0/11-control-plane.md`](../../spec/v0/11-control-plane.md) — control plane wire surface as it exists
+- [`docs/glossary.md`](../glossary.md) — canonical vocabulary

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -328,6 +328,16 @@ Metric values are type-checked against the schema before submission. For integer
 
 ## 8. Workflow 4: admin operations
 
+This section covers the mutating admin actions. For read-only inspection (tasks / ideas / variants / events / workers via wire API or SQL), see [`docs/observability.md`](observability.md).
+
+Boilerplate for the wire-API examples below:
+
+```bash
+ADMIN=$(grep '^EDEN_ADMIN_TOKEN=' reference/compose/.env | cut -d= -f2)
+H=(-H "Authorization: Bearer admin:$ADMIN" -H "X-Eden-Experiment-Id: <id>")
+BASE="http://localhost:8080/v0/experiments/<id>"
+```
+
 ### Reclaiming a stuck task
 
 If a worker died holding a claim and the claim has no `expires_at`, the task is stuck `claimed` forever.
@@ -335,29 +345,13 @@ If a worker died holding a claim and the claim has no `expires_at`, the task is 
 - **Web UI:** `http://localhost:8090/admin/tasks/<task-id>/` exposes a "reclaim" button (and a separate "force-reclaim, replays work" variant for already-submitted tasks).
 - **Wire API:** `POST /v0/experiments/<id>/tasks/<task-id>/reclaim` with `{"cause": "operator"}`. **Requires a worker bearer**, not admin (per spec §13.3, admin bearers MUST NOT call worker-gated endpoints). Workers' own bearers are inside the corresponding containers; in practice, use the Web UI.
 
-### Inspecting state
-
-```bash
-ADMIN=$(grep '^EDEN_ADMIN_TOKEN=' reference/compose/.env | cut -d= -f2)
-H=(-H "Authorization: Bearer admin:$ADMIN" -H "X-Eden-Experiment-Id: <id>")
-BASE="http://localhost:8080/v0/experiments/<id>"
-
-curl -s "${H[@]}" "$BASE/tasks"          | jq
-curl -s "${H[@]}" "$BASE/ideas"          | jq
-curl -s "${H[@]}" "$BASE/variants"       | jq
-curl -s "${H[@]}" "$BASE/events?cursor=0" | jq '.events'
-curl -s "${H[@]}" "$BASE/workers"        | jq
-```
-
 ### Worker registry
 
 ```bash
-curl -s "${H[@]}" "$BASE/workers"                       # list
-curl -s "${H[@]}" "$BASE/workers/<worker-id>"           # read one
 curl -s "${H[@]}" -X POST "$BASE/workers/<worker-id>/reissue-credential"  # rotate
 ```
 
-Worker IDs match `^[a-z0-9][a-z0-9_-]{0,63}$`. `admin`, `system`, `internal` are reserved.
+Worker IDs match `^[a-z0-9][a-z0-9_-]{0,63}$`. `admin`, `system`, `internal` are reserved. To list / read the registry, see [`observability.md` §2.4](observability.md#24-wire-api-raw).
 
 ### Work-ref garbage collection
 
@@ -365,41 +359,7 @@ Worker IDs match `^[a-z0-9][a-z0-9_-]{0,63}$`. `admin`, `system`, `internal` are
 
 ## 9. Workflow 5: passive observation
 
-### The Forgejo Web UI
-
-`http://localhost:3001/eden/<experiment-id>` — sign in as user `eden` (password is `FORGEJO_REMOTE_PASSWORD` in `.env`). Browse branches (`work/*`, `variant/*`, `main`), diff arbitrary commits, inspect any tree including the `.eden/variants/<id>/evaluation.json` manifests the integrator adds. Best for casual browsing.
-
-### A read-only local clone
-
-```bash
-PASS=$(grep '^FORGEJO_REMOTE_PASSWORD=' reference/compose/.env | cut -d= -f2)
-git clone "http://eden:${PASS}@localhost:3001/eden/<experiment-id>.git" /tmp/eden-readonly
-cd /tmp/eden-readonly
-git log --all --decorate --oneline --graph
-```
-
-Refresh with `git fetch --all --prune`. Never push from this clone.
-
-### The wire API
-
-For non-git state — tasks, variants, events, workers, audit. See [§8](#8-workflow-4-admin-operations) for one-liners.
-
-### The Web UI admin dashboards
-
-`http://localhost:8090/admin/` — read-only dashboards over tasks (with claim-age + claim-expired badges), variants (filterable by status), and the event log. Per-task and per-variant detail pages that cross-link to related events.
-
-### Watching live
-
-```bash
-docker compose --env-file reference/compose/.env logs -f orchestrator
-docker compose --env-file reference/compose/.env logs -f web-ui
-```
-
-Or watch the event stream:
-
-```bash
-curl -s "${H[@]}" "$BASE/events?cursor=0" | jq '.events[].type' | tail -30
-```
+Moved to [`docs/observability.md`](observability.md). That doc enumerates every surface — first-party (web UI admin dashboards, Forgejo, artifacts directory, wire API, container logs, readonly Postgres role) and bring-your-own (Adminer, Swagger UI, desktop clients).
 
 ## 10. Auth principal matrix
 

--- a/reference/compose/compose.control-plane.yaml
+++ b/reference/compose/compose.control-plane.yaml
@@ -1,0 +1,42 @@
+name: eden-reference
+
+services:
+  web-ui:
+    command:
+      - python
+      - -m
+      - eden_web_ui
+      - --task-store-url
+      - http://task-store-server:8080
+      - --experiment-id
+      - ${EDEN_EXPERIMENT_ID:?}
+      - --admin-token
+      - ${EDEN_ADMIN_TOKEN:?}
+      - --experiment-config
+      - /etc/eden/experiment-config.yaml
+      - --session-secret
+      - ${EDEN_SESSION_SECRET:?EDEN_SESSION_SECRET must be set (run setup-experiment)}
+      - --artifacts-dir
+      - /var/lib/eden/artifacts
+      - --repo-path
+      - /var/lib/eden/repo
+      - --forgejo-url
+      - ${FORGEJO_REMOTE_URL:?}
+      - --credential-helper
+      - /etc/eden/credential-helper.sh
+      - --clone-url
+      - ${FORGEJO_CLONE_URL_HOST:-http://localhost:${FORGEJO_HOST_PORT:-3001}/eden/${EDEN_EXPERIMENT_ID:?}.git}
+      - --base-commit-sha
+      - ${EDEN_BASE_COMMIT_SHA:?EDEN_BASE_COMMIT_SHA must be set (run setup-experiment)}
+      - --worker-id
+      - ${EDEN_WEB_UI_WORKER_ID:-web-ui-1}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8090"
+      - --log-level
+      - info
+      - --control-plane-url
+      - ${EDEN_CONTROL_PLANE_URL:?EDEN_CONTROL_PLANE_URL must be set when layering compose.control-plane.yaml}
+      - --control-plane-admin-token
+      - ${EDEN_ADMIN_TOKEN:?}

--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -1,10 +1,17 @@
 name: eden-reference
 
+x-eden-logging: &eden-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "5"
+
 services:
   postgres:
     image: postgres:16.6-alpine
     container_name: eden-postgres
     restart: unless-stopped
+    logging: *eden-logging
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-eden}
       POSTGRES_USER: ${POSTGRES_USER:-eden}
@@ -28,6 +35,7 @@ services:
     image: codeberg.org/forgejo/forgejo:11-rootless
     container_name: eden-forgejo
     restart: unless-stopped
+    logging: *eden-logging
     environment:
       FORGEJO__server__DOMAIN: localhost
       FORGEJO__server__ROOT_URL: http://localhost:${FORGEJO_HOST_PORT:-3001}/
@@ -103,6 +111,7 @@ services:
       dockerfile: reference/compose/Dockerfile
     container_name: eden-task-store-server
     restart: unless-stopped
+    logging: *eden-logging
     depends_on:
       postgres:
         condition: service_healthy
@@ -185,6 +194,7 @@ services:
     # something to recover from and re-run the loop in a tight
     # restart cycle. `on-failure` lets a clean exit stick.
     restart: "on-failure"
+    logging: *eden-logging
     depends_on:
       task-store-server:
         condition: service_healthy
@@ -261,6 +271,7 @@ services:
       dockerfile: reference/compose/Dockerfile
     container_name: eden-ideator-host
     restart: unless-stopped
+    logging: *eden-logging
     depends_on:
       task-store-server:
         condition: service_healthy
@@ -291,6 +302,7 @@ services:
       dockerfile: reference/compose/Dockerfile
     container_name: eden-executor-host
     restart: unless-stopped
+    logging: *eden-logging
     depends_on:
       task-store-server:
         condition: service_healthy
@@ -327,6 +339,7 @@ services:
       dockerfile: reference/compose/Dockerfile
     container_name: eden-evaluator-host
     restart: unless-stopped
+    logging: *eden-logging
     depends_on:
       task-store-server:
         condition: service_healthy
@@ -360,6 +373,7 @@ services:
       dockerfile: reference/compose/Dockerfile
     container_name: eden-web-ui
     restart: unless-stopped
+    logging: *eden-logging
     depends_on:
       task-store-server:
         condition: service_healthy


### PR DESCRIPTION
Cherry-picked from `demo/operator-exploration` after #125 (#119), #126 (#118), and #159 (#129) split off the bug-fixes from the same branch. This PR carries the non-bug-fix work from the same demo session.

## Commits

| Commit | What |
|---|---|
| `4be95f4` | compose: bump log retention to 50m × 5 across eden services — L1 of the persistence ladder discussed in #109. |
| `20752d6` | compose: add control-plane overlay for /admin/experiments/ — opt-in overlay wiring the Phase 12c multi-experiment registry through the web-ui. |
| `666b80c` | docs: extract observability guide and cross-link from user-guide — splits the operator walkthrough and the surface-enumeration that had drifted into overlap. |
| `30b2126` | docs(prds): draft EDEN as an experiment platform — long-horizon vision (centralized controller + substrate adapters + multi-experiment binding). |

## Dropped during cherry-pick

- The original `.gitignore` patch (`f052970`) was a no-op — main already has both `.gitea-creds-*` and `.forgejo-creds-*` patterns from #113.
- The three bug-fix commits (`c2938f8` #118 / `a721a7c` #119 / `57755d4` + `89cb328` #129) shipped via PRs #126 / #125 / #159 respectively.

## Validation

- markdownlint: clean
- spec-xref-check: clean
- rename-discipline: clean

Smokes not run locally (no functional code changes; the control-plane overlay is opt-in).