### PR TITLE
Fix #130: bind-mount Forgejo /etc/gitea config dir for full durability

### DIFF
--- a/docs/operations/experiment-data-durability.md
+++ b/docs/operations/experiment-data-durability.md
@@ -10,6 +10,7 @@ After running `setup-experiment.sh`, every durable substrate is a **host bind-mo
 $EDEN_EXPERIMENT_DATA_ROOT/
 ├── postgres/              # task-store-server's PostgresStore data
 ├── forgejo/                 # Forgejo's data (sqlite DB, git packs, …)
+├── forgejo-etc/           # Forgejo's config dir (app.ini, SSH host keys)
 ├── artifacts/             # web-ui --artifacts-dir (idea markdown, …)
 ├── orchestrator-repo/     # orchestrator's per-host bare clone
 ├── executor-repo/         # executor-host's per-host bare clone
@@ -107,7 +108,7 @@ cd reference/compose
 docker compose --env-file .env stop
 
 # Create the bind-mount tree.
-mkdir -p "$ROOT"/{postgres,forgejo,artifacts,orchestrator-repo,executor-repo,evaluator-repo,web-ui-repo,credentials/{orchestrator,ideator,executor,evaluator,web-ui}}
+mkdir -p "$ROOT"/{postgres,forgejo,forgejo-etc,artifacts,orchestrator-repo,executor-repo,evaluator-repo,web-ui-repo,credentials/{orchestrator,ideator,executor,evaluator,web-ui}}
 chmod -R 0777 "$ROOT"
 
 # Copy each substrate from its named volume into the new bind-mount.
@@ -212,7 +213,7 @@ done
 docker compose --env-file "$ENV_FILE" -f reference/compose/compose.yaml down
 
 # 4. Verify substrate tree is still populated on the host filesystem.
-ls "$ROOT/postgres" "$ROOT/forgejo" "$ROOT/artifacts"
+ls "$ROOT/postgres" "$ROOT/forgejo" "$ROOT/forgejo-etc" "$ROOT/artifacts"
 
 # 5. Bring the stack back up against the same data root + env file.
 docker compose --env-file "$ENV_FILE" -f reference/compose/compose.yaml up -d --wait

--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -81,6 +81,21 @@ services:
       # under our control and uses the Forgejo brand name. The
       # container target is image-defined; do not rename it.
       - ${EDEN_EXPERIMENT_DATA_ROOT:?EDEN_EXPERIMENT_DATA_ROOT must be set (run setup-experiment)}/forgejo:/var/lib/gitea
+      # Companion config bind-mount (issue #130, follow-up to #129).
+      # The container target is `/etc/gitea`, NOT `/etc/forgejo`, for
+      # the same reason as the data mount above: the upstream image's
+      # VOLUME declaration retains Gitea's legacy paths, and Forgejo
+      # writes its generated `app.ini` (plus other config state — the
+      # internal SSH host keys it derives from FORGEJO__security__*,
+      # any operator-edited overrides applied via `forgejo admin`) to
+      # `/etc/gitea/` regardless of the brand. Without this mount the
+      # config dir is backed by an anonymous Docker volume that does
+      # NOT survive Docker Desktop VM restarts or `docker volume
+      # prune`, so a `compose down` (or even `docker volume prune`)
+      # silently discards every config change. The data mount alone
+      # is not enough — Forgejo splits durable state across both
+      # directories.
+      - ${EDEN_EXPERIMENT_DATA_ROOT:?EDEN_EXPERIMENT_DATA_ROOT must be set (run setup-experiment)}/forgejo-etc:/etc/gitea
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/v1/version"]
       interval: 5s

--- a/reference/scripts/setup-experiment/setup-experiment.sh
+++ b/reference/scripts/setup-experiment/setup-experiment.sh
@@ -326,6 +326,7 @@ fi
 mkdir -p \
     "${EDEN_EXPERIMENT_DATA_ROOT}/postgres" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/forgejo" \
+    "${EDEN_EXPERIMENT_DATA_ROOT}/forgejo-etc" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/artifacts" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/orchestrator-repo" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/executor-repo" \
@@ -341,6 +342,7 @@ if ! chmod 0777 \
     "${EDEN_EXPERIMENT_DATA_ROOT}" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/postgres" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/forgejo" \
+    "${EDEN_EXPERIMENT_DATA_ROOT}/forgejo-etc" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/artifacts" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/orchestrator-repo" \
     "${EDEN_EXPERIMENT_DATA_ROOT}/executor-repo" \


### PR DESCRIPTION
Closes #130. Follow-up to #129 (PR #159, just merged).

## Summary

- PR #159 added the data-dir bind-mount at `/var/lib/gitea` so Forgejo's repos + sqlite DB survive `compose down`.
- The companion config dir at `/etc/gitea` was still backed by an **anonymous Docker volume** from the image's `VOLUME ["/etc/gitea", "/var/lib/gitea"]` declaration. Forgejo's generated `app.ini` (and the SSH host keys it derives from `FORGEJO__security__*` env) silently disappears on Docker Desktop VM restart / `docker volume prune` — the same failure mode #129 fixed for the data dir, just for the config half.
- Adds a second host bind-mount: `$EDEN_EXPERIMENT_DATA_ROOT/forgejo-etc` → `/etc/gitea`.

## Why `/etc/gitea`, not `/etc/forgejo`?

Same reason `/var/lib/gitea` was the right target in #129: the upstream Forgejo image is a soft fork of Gitea and its Dockerfile declares `VOLUME ["/etc/gitea", "/var/lib/gitea"]` to preserve migration compatibility. Forgejo writes its config to `/etc/gitea/` regardless of brand. The container target is image-defined; the host-side path uses the Forgejo brand for operator clarity. Inline comment block in `compose.yaml` mirrors the annotation pattern #159 introduced for `/var/lib/gitea`.

## Changes

- `reference/compose/compose.yaml` — second `${EDEN_EXPERIMENT_DATA_ROOT}/forgejo-etc:/etc/gitea` bind-mount on the `forgejo` service, with an inline comment explaining why `/etc/gitea` and why the data mount alone is insufficient.
- `reference/scripts/setup-experiment/setup-experiment.sh` — creates `${EDEN_EXPERIMENT_DATA_ROOT}/forgejo-etc/` and chmod 0777 it alongside the existing substrate dirs.
- `docs/operations/experiment-data-durability.md` — `forgejo-etc/` added to the substrate-tree diagram, the legacy-volume migration `mkdir`, and the durability-recipe verification `ls`.

## Test plan

- [x] `npx --yes markdownlint-cli2@0.14.0 …` — clean
- [x] `docker compose -f compose.yaml config` resolves both forgejo bind-mounts: `source: <root>/forgejo target: /var/lib/gitea` and `source: <root>/forgejo-etc target: /etc/gitea`
- [ ] CI smoke (`compose-smoke` / `compose-smoke-subprocess` / `compose-e2e`) — defers to PR-CI; local smoke skipped because an active demo stack (44h) is running in the same docker host and smoke.sh would tear it down. Mechanical change; same shape as #159 which CI already validated for the data dir.
- [ ] **Durability** (run post-merge against a fresh stack): modify some forgejo config (e.g. change the eden user's display name through the UI), `compose down`, `compose up -d --wait`, confirm the change persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)