### PR TITLE
Fix #161: executor UI clone instruction includes Forgejo credentials

### DIFF
--- a/reference/compose/.env.example
+++ b/reference/compose/.env.example
@@ -27,7 +27,10 @@ FORGEJO_REMOTE_PASSWORD=eden-dev-forgejo-password-change-me
 # In-network URL the workers use to clone/push.
 FORGEJO_REMOTE_URL=http://forgejo:3000/eden/${EDEN_EXPERIMENT_ID}.git
 # Host-accessible URL surfaced in the implementer UI for users to clone.
-FORGEJO_CLONE_URL_HOST=http://localhost:${FORGEJO_HOST_PORT}/eden/${EDEN_EXPERIMENT_ID}.git
+# Embeds HTTP Basic credentials so `git clone` works directly (issue #161,
+# local-demo posture). Override for deployments where rendering the
+# password in the UI is unacceptable.
+FORGEJO_CLONE_URL_HOST=http://eden:${FORGEJO_REMOTE_PASSWORD}@localhost:${FORGEJO_HOST_PORT}/eden/${EDEN_EXPERIMENT_ID}.git
 
 # --- Task store / web UI ports ---
 WEB_UI_HOST_PORT=8090

--- a/reference/compose/compose.yaml
+++ b/reference/compose/compose.yaml
@@ -420,7 +420,13 @@ services:
       - --credential-helper
       - /etc/eden/credential-helper.sh
       - --clone-url
-      - ${FORGEJO_CLONE_URL_HOST:-http://localhost:${FORGEJO_HOST_PORT:-3001}/eden/${EDEN_EXPERIMENT_ID:?}.git}
+      # Embed HTTP Basic credentials so the operator-facing `git clone`
+      # command works directly (issue #161). Local-demo posture: the
+      # password is rendered in the executor draft page HTML. Override
+      # FORGEJO_CLONE_URL_HOST to point at a remote where the operator
+      # already has credentials configured for deployments where this
+      # leakage is unacceptable.
+      - ${FORGEJO_CLONE_URL_HOST:-http://eden:${FORGEJO_REMOTE_PASSWORD:?}@localhost:${FORGEJO_HOST_PORT:-3001}/eden/${EDEN_EXPERIMENT_ID:?}.git}
       - --base-commit-sha
       - ${EDEN_BASE_COMMIT_SHA:?EDEN_BASE_COMMIT_SHA must be set (run setup-experiment)}
       - --worker-id

--- a/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
@@ -51,7 +51,7 @@
             <pre><code>git clone {{ clone_url }} my-checkout
 cd my-checkout
 git checkout {{ idea.parent_commits[0] }}</code></pre>
-            HTTP Basic credentials live in <code>reference/compose/.env</code> as <code>FORGEJO_REMOTE_PASSWORD</code> (username <code>eden</code>).</li>
+            The clone URL embeds HTTP Basic credentials for the <code>eden</code> Forgejo user (issue #161). Local-demo posture only — anyone with web UI access can read this password. Override <code>FORGEJO_CLONE_URL_HOST</code> in <code>.env</code> for deployments where this leakage is unacceptable.</li>
         <li>Make your changes, commit, and push your branch back to the central repo:
             <pre><code>git checkout -b my-work
 # (edit, stage, commit)

--- a/reference/services/web-ui/tests/conftest.py
+++ b/reference/services/web-ui/tests/conftest.py
@@ -294,6 +294,31 @@ def signed_in_impl_client_with_clone_url(
         yield c
 
 
+@pytest.fixture
+def exec_app_with_clone_url_fixture(
+    store: InMemoryStore, artifacts_dir: Path, bare_repo: GitRepo
+) -> Iterator[TestClient]:
+    """Signed-in client whose ``--clone-url`` embeds HTTP Basic credentials
+    (the local-demo default — see issue #161)."""
+    app = make_app(
+        store=store,
+        experiment_id=EXPERIMENT_ID,
+        experiment_config=_config(),
+        worker_id=WORKER_ID,
+        session_secret=SESSION_SECRET,
+        claim_ttl_seconds=3600,
+        artifacts_dir=artifacts_dir,
+        secure_cookies=False,
+        now=_now,
+        repo=bare_repo,
+        clone_url="http://eden:demo-password@forgejo.example/eden/exp.git",
+    )
+    with TestClient(app) as c:
+        resp = c.post("/signin", follow_redirects=False)
+        assert resp.status_code == 303
+        yield c
+
+
 def seed_implement_task(
     store: InMemoryStore,
     *,

--- a/reference/services/web-ui/tests/test_executor_routes.py
+++ b/reference/services/web-ui/tests/test_executor_routes.py
@@ -338,6 +338,24 @@ class TestCloneUrlInstructions:
         assert "Push your tip commit" not in resp.text
         assert "/var/lib/eden/repo" not in resp.text
 
+    def test_clone_url_renders_embedded_credentials_verbatim(
+        self,
+        exec_app_with_clone_url_fixture: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+    ) -> None:
+        """Issue #161: when the operator configures ``--clone-url`` with
+        embedded HTTP Basic credentials (the local-demo default), the
+        draft page must render the URL verbatim — including the
+        ``eden:<password>@`` prefix — so the displayed ``git clone``
+        command works without the operator having to look up Forgejo's
+        password separately."""
+        client = exec_app_with_clone_url_fixture
+        task_id = self._claim(client, store, base_sha)
+        resp = client.get(f"/executor/{task_id}/draft")
+        assert resp.status_code == 200
+        assert "http://eden:demo-password@forgejo.example/eden/exp.git" in resp.text
+
     def test_no_clone_url_warns_about_missing_clone_endpoint(
         self,
         signed_in_impl_client: TestClient,


### PR DESCRIPTION
Closes #161.

## Summary

Web UI's executor draft page rendered `git clone <url>` without HTTP Basic credentials, so operators copy-pasting the command from the page got `Credentials are incorrect or have expired` from Forgejo. The credentials were available (setup-experiment writes `FORGEJO_REMOTE_PASSWORD` to `.env`) but the operator had no signal from the UI about how to authenticate.

This implements the issue's Option A recommendation (embed credentials in the displayed URL, gated on a config flag for production deployments).

## Changes

- `reference/compose/compose.yaml`: `--clone-url` default now embeds `eden:${FORGEJO_REMOTE_PASSWORD}@` before the host so the operator can copy-paste directly.
- `reference/compose/.env.example`: same shape for `FORGEJO_CLONE_URL_HOST`'s example value, with a comment pointing at the override.
- `reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html`: replaced the stale "credentials live in reference/compose/.env" line with a security note that says the URL embeds credentials (local-demo posture) and points at the `FORGEJO_CLONE_URL_HOST` override for deployments where rendering the password is unacceptable.
- Test: `test_clone_url_renders_embedded_credentials_verbatim` asserts the URL renders verbatim with the `eden:<password>@` prefix.

## What this does NOT cover

- The issue noted a "probably also `/admin/variants/<id>/`" affected view; the admin variant detail template carries no Forgejo URL today, so no change needed there.
- `eden-manual-executor` skill — uses the on-host credential-helper script and is unaffected by this UI fix.
- `docs/user-guide.md` already documents the credential-embedded URL at line 293, so no doc update needed.

## Test plan

- [x] `uv run pytest -q reference/services/web-ui/tests/` — 508 passed
- [x] `uv run ruff check reference/services/web-ui/`
- [x] `uv run pyright reference/services/web-ui/`
- [ ] Manual smoke: bring up the Compose stack, claim an execution task, copy the rendered `git clone` command, run it against the host Forgejo, verify it succeeds without prompting for credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)