### PR TITLE
Fix #163: executor submit form shows how to get commit_sha

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -262,7 +262,7 @@ The executor turns one execution task (which references an idea) into a git comm
 
 ### Execution via the Web UI
 
-Claim a pending execution task on the executor page. The form surfaces the idea (slug / parents / rationale, rendered inline if the artifact is reachable). You provide the `commit_sha` of your already-pushed branch; the UI does the create-variant + ref-create + submit. **You're responsible for getting the commit into Forgejo** before pasting the SHA — clone forgejo locally, edit, commit, push.
+Claim a pending execution task on the executor page. The form surfaces the idea (slug / parents / rationale, rendered inline if the artifact is reachable). You provide the `commit_sha` of your already-pushed branch; the UI does the create-variant + ref-create + submit. **You're responsible for getting the commit into Forgejo** before pasting the SHA — clone forgejo locally, edit, commit, push, then run `git rev-parse HEAD` in your worktree to print the SHA to paste.
 
 ### Execution via the CLI (full end-to-end)
 

--- a/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
@@ -56,12 +56,18 @@ git checkout {{ idea.parent_commits[0] }}</code></pre>
             <pre><code>git checkout -b my-work
 # (edit, stage, commit)
 git push origin my-work</code></pre></li>
-        <li>Paste the resulting commit SHA below and submit. The UI fetches from origin on submit, then creates the canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit.</li>
+        <li>Print the commit SHA you just pushed:
+            <pre><code>git rev-parse HEAD</code></pre>
+            Copy the 40-character hex output and paste it into the <code>commit_sha</code> field below.</li>
+        <li>Submit. The UI fetches from origin, then creates the canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit.</li>
         {% else %}
         <li><strong>Note:</strong> this deployment has no <code>--clone-url</code> configured, so the UI can't show a clone command. Ask your operator how to obtain pushable access to the central repo
             {% if repo_path %}(the server's local clone path is <code>{{ repo_path }}</code>, but that is inside the web-ui process — not a URL you can push to from a workstation){% endif %}.</li>
         <li>Once you have access, work on a checkout with parents matching <code>parent_commits</code> above, then push your tip commit to the central repo.</li>
-        <li>Paste the resulting commit SHA below and submit. The UI will fetch from origin, then create the canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit.</li>
+        <li>Print the commit SHA you just pushed:
+            <pre><code>git rev-parse HEAD</code></pre>
+            Copy the 40-character hex output and paste it into the <code>commit_sha</code> field below.</li>
+        <li>Submit. The UI will fetch from origin, then create the canonical ref <code>refs/heads/{{ branch }}</code> pointing at your commit.</li>
         {% endif %}
     </ol>
 </section>

--- a/reference/services/web-ui/tests/test_executor_routes.py
+++ b/reference/services/web-ui/tests/test_executor_routes.py
@@ -371,3 +371,35 @@ class TestCloneUrlInstructions:
         # local-fs path.
         assert "no <code>--clone-url</code> configured" in resp.text
         assert "not a URL you can push to from a workstation" in resp.text
+
+    def test_clone_url_path_shows_rev_parse_hint(
+        self,
+        signed_in_impl_client_with_clone_url: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+    ) -> None:
+        # Issue #163: the form must tell the operator how to obtain the
+        # commit SHA they're being asked to paste — `git rev-parse HEAD`
+        # in their worktree.
+        task_id = self._claim(
+            signed_in_impl_client_with_clone_url, store, base_sha
+        )
+        resp = signed_in_impl_client_with_clone_url.get(
+            f"/executor/{task_id}/draft"
+        )
+        assert resp.status_code == 200
+        assert "git rev-parse HEAD" in resp.text
+
+    def test_no_clone_url_path_shows_rev_parse_hint(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        base_sha: str,
+    ) -> None:
+        # Issue #163: the rev-parse hint must appear on the no-clone-url
+        # fallback path too — that branch of the template walks the
+        # operator through the same SHA-pasting step.
+        task_id = self._claim(signed_in_impl_client, store, base_sha)
+        resp = signed_in_impl_client.get(f"/executor/{task_id}/draft")
+        assert resp.status_code == 200
+        assert "git rev-parse HEAD" in resp.text


### PR DESCRIPTION
## Summary

- Executor draft template walked operators through clone / edit / push with concrete commands, then jumped to "paste the resulting commit SHA" with no instruction on how to obtain it. First-time operators (discovered during the 2026-05-22 manual demo) get stuck at the SHA-paste step.
- Add an explicit `git rev-parse HEAD` step between the push step and the submit step on both branches of `executor_claim.html` (clone_url configured + fallback path). Mirror the hint in `docs/user-guide.md` §6.
- Add two route tests asserting the new help text renders on both template branches.

## What this does NOT cover

- Auto-prefill of the `commit_sha` field via a Forgejo-API lookup (option 2 from the issue brief) — out of scope; this PR ships the minimal help-text fix.
- The cousin issue #161 (executor UI clone-creds discoverability) — separate PR.

No deferred items beyond the explicitly-out-of-scope auto-prefill (it was framed as an alternative, not a follow-up commitment).

## Fresh-operator walkthrough

N/A in this session — change is a help-text-only addition to a template branch already exercised by existing render tests. The two new tests assert the canonical command (`git rev-parse HEAD`) appears in both rendered template branches. Visual rendering of the new `<pre><code>` block follows the same pattern as the adjacent clone / push command blocks already in the template, which have been operator-validated previously.

## Test plan

- [x] `uv run pytest -q reference/services/web-ui/tests/` (509 passed)
- [x] `uv run ruff check reference/services/web-ui/`
- [x] `npx --yes markdownlint-cli2@0.14.0 "docs/user-guide.md"`
- [ ] `bash reference/compose/healthcheck/smoke.sh` — skipped: template-only change, no service-binary behavior altered

## Related issues

Closes #163. Cousin of #161 (same shape: walkthrough has specific commands for some steps and bare placeholders for others).