### PR TITLE
Add merge_group trigger to CI workflow (prep for merge queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   docs-lint:


### PR DESCRIPTION
## Summary

Adds the \`merge_group:\` trigger to \`.github/workflows/ci.yml\` so the CI workflow fires on GitHub merge-queue events. Required before enabling merge queue on the main branch.

## Why

GitHub merge queue solves the auto-merge cascade problem: when N PRs are auto-merge-flagged and PR #1 lands, PRs #2..N transition to \`BEHIND\` state and auto-merge silently sits until someone rebases. With merge queue enabled, GitHub itself rebases each queued PR onto the projected post-merge \`main\`, runs CI once per queued state, and merges serially without manual intervention.

The pure ingredient required is the \`merge_group:\` trigger; without it the CI workflow won't fire on queue events and queued PRs stall waiting for required status checks.

## Sequence

1. **This PR**: add the trigger (one-line addition; zero behavior change to existing \`push\` / \`pull_request\` flows).
2. **After merge**: enable merge queue on the \`main\` branch via branch protection.

## What this does NOT cover

- Branch protection toggle (manual / separate step after this lands).
- Adjustments to required-status-check names if merge queue surfaces different check IDs (will iterate on first real queue run if needed).

## Fresh-operator walkthrough

N/A — workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)