### PR TITLE
Fix #167: evaluator form validates artifacts_uri readability at submit

### DIFF
--- a/reference/services/web-ui/src/eden_web_ui/routes/_helpers.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/_helpers.py
@@ -130,3 +130,55 @@ def read_variant_artifact(
     optional and may be ``None``, which short-circuits to ``None``.
     """
     return _read_inline_artifact(artifacts_uri, artifacts_dir)
+
+
+def validate_file_artifact_uri(
+    artifacts_uri: str | None, artifacts_dir: Path
+) -> str | None:
+    """Validate that an operator-supplied ``file://`` URI is readable.
+
+    Returns ``None`` if the URI is acceptable, or an operator-facing
+    error string. Acceptance rules:
+
+    - ``None`` / empty → accepted (the field is optional).
+    - Non-``file://`` schemes (``http``, ``https``, etc.) → accepted
+      without further check; remote schemes can't be probed server-side.
+    - ``file://`` URIs MUST resolve to an existing regular file under
+      ``artifacts_dir.resolve()`` (the substrate's artifact jail).
+
+    Issue #167: previously the form silently accepted any string; an
+    operator typing ``file:///eval.md`` (missing the artifacts-dir
+    prefix) escaped the jail and the resulting submission later 404'd
+    on read, with the URI locked in by the first-write-wins resubmit
+    rule.
+    """
+    if artifacts_uri is None:
+        return None
+    if not artifacts_uri:
+        return None
+    parsed = urlparse(artifacts_uri)
+    if parsed.scheme != "file":
+        return None
+    raw_path = unquote(parsed.path)
+    if not raw_path:
+        return "artifacts_uri path is empty"
+    base = artifacts_dir.resolve()
+    try:
+        resolved = Path(raw_path).resolve()
+    except OSError as exc:
+        return f"artifacts_uri could not be resolved: {exc.strerror or exc}"
+    if not resolved.is_relative_to(base):
+        return (
+            f"artifacts_uri must point to a file under {base} "
+            f"(got {resolved})"
+        )
+    if not resolved.exists():
+        return f"artifacts_uri does not exist at {resolved}"
+    if not resolved.is_file():
+        return f"artifacts_uri is not a regular file: {resolved}"
+    try:
+        with resolved.open("rb") as fh:
+            fh.read(1)
+    except OSError as exc:
+        return f"artifacts_uri is not readable: {exc.strerror or exc}"
+    return None

--- a/reference/services/web-ui/src/eden_web_ui/routes/evaluator.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/evaluator.py
@@ -48,6 +48,7 @@ from ._helpers import (
     is_htmx_request,
     read_idea_content,
     read_variant_artifact,
+    validate_file_artifact_uri,
 )
 from ._submit_readback import submit_with_readback, wire_error_banner
 
@@ -281,6 +282,43 @@ def _collect_metric_inputs(form: Any, evaluation_schema: Any) -> dict[str, str]:
     return metric_inputs
 
 
+def _parse_and_validate_evaluate_form(
+    *,
+    form: Any,
+    evaluation_schema: Any,
+    artifacts_dir: Any,
+) -> tuple[Any, Any, dict[str, Any]]:
+    """Parse the evaluator submit form and apply the substrate-side
+    ``artifacts_uri`` readability check (issue #167).
+
+    Returns ``(draft, errors, form_state)`` where ``draft`` is the
+    validated :class:`EvaluationDraft` when parsing + URI validation
+    both succeed, else ``None`` with the corresponding :class:`FormErrors`
+    populated for re-render. ``form_state`` always carries the operator's
+    typed values so the re-rendered form preserves them.
+    """
+    status_raw = str(form.get("status") or "")
+    artifacts_uri_raw = str(form.get("artifacts_uri") or "")
+    metric_inputs = _collect_metric_inputs(form, evaluation_schema)
+    draft, errors = parse_evaluate_form(
+        evaluation_schema=evaluation_schema,
+        status_raw=status_raw,
+        metric_inputs=metric_inputs,
+        artifacts_uri_raw=artifacts_uri_raw,
+    )
+    form_state: dict[str, Any] = {
+        "status": status_raw or "success",
+        "artifacts_uri": artifacts_uri_raw,
+        "metric_values": dict(metric_inputs),
+    }
+    if draft is not None:
+        uri_error = validate_file_artifact_uri(draft.artifacts_uri, artifacts_dir)
+        if uri_error is not None:
+            errors.add(0, "artifacts_uri", uri_error)
+            draft = None
+    return draft, errors, form_state
+
+
 def _finalize_evaluator_submit(
     *,
     request: Request,
@@ -371,23 +409,11 @@ async def submit(
         )
 
     config = request.app.state.experiment_config
-    evaluation_schema = config.evaluation_schema
-
-    status_raw = str(form.get("status") or "")
-    artifacts_uri_raw = str(form.get("artifacts_uri") or "")
-    metric_inputs = _collect_metric_inputs(form, evaluation_schema)
-
-    draft, errors = parse_evaluate_form(
-        evaluation_schema=evaluation_schema,
-        status_raw=status_raw,
-        metric_inputs=metric_inputs,
-        artifacts_uri_raw=artifacts_uri_raw,
+    draft, errors, form_state = _parse_and_validate_evaluate_form(
+        form=form,
+        evaluation_schema=config.evaluation_schema,
+        artifacts_dir=request.app.state.artifacts_dir,
     )
-    form_state: dict[str, Any] = {
-        "status": status_raw or "success",
-        "artifacts_uri": artifacts_uri_raw,
-        "metric_values": dict(metric_inputs),
-    }
     if draft is None:
         return _render_draft(
             request,

--- a/reference/services/web-ui/src/eden_web_ui/templates/evaluator_claim.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/evaluator_claim.html
@@ -144,7 +144,13 @@
         <p>
             <label for="artifacts_uri">artifacts_uri (optional; URI to your eval logs / output)</label><br>
             <input type="text" id="artifacts_uri" name="artifacts_uri" size="60"
+                placeholder="file:///var/lib/eden/artifacts/<filename>"
+                title="Absolute path under /var/lib/eden/artifacts/ inside the container; equivalently, ${EDEN_EXPERIMENT_DATA_ROOT}/artifacts/<filename> on the host."
                 value="{{ form_state.artifacts_uri }}">
+            {% if errors and errors.by_row.get(0, {}).get("artifacts_uri") %}
+            <span class="field-error">{{ errors.by_row[0]["artifacts_uri"] }}</span>
+            {% endif %}
+            <br><small>Optional. For <code>file://</code> URIs, point inside the container's artifacts directory; place the file at the host bind-mount. HTTP(S) URIs to external logs are also accepted.</small>
         </p>
         <button type="submit">submit</button>
     </form>

--- a/reference/services/web-ui/tests/test_evaluator_routes.py
+++ b/reference/services/web-ui/tests/test_evaluator_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from urllib.parse import urlencode
 
 import pytest
@@ -328,6 +329,91 @@ class TestSubmitValidation:
         assert recorded.variant_id == variant_id
         assert recorded.evaluation == {"score": 0.875}
         assert recorded.artifacts_uri == "https://logs.example/run/42"
+
+    def test_file_uri_outside_artifacts_dir_rejected(
+        self,
+        signed_in_client: TestClient,
+        store: InMemoryStore,
+    ) -> None:
+        """Issue #167: a ``file://`` URI escaping the artifacts jail must
+        re-render the form with an inline field-level error instead of
+        silently accepting and locking in the bad URI (first-write-wins
+        on resubmit per spec §4.2 would otherwise make this unfixable).
+        """
+        eval_id, _, _ = seed_evaluate_task(store)
+        csrf = self._claim(signed_in_client, eval_id)
+        resp = _post_form(
+            signed_in_client,
+            f"/evaluator/{eval_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("metric.score", "0.5"),
+                ("artifacts_uri", "file:///eval.md"),
+            ],
+        )
+        assert resp.status_code == 400
+        assert "artifacts_uri must point to a file under" in resp.text
+        # Submission must NOT have landed.
+        assert store.read_submission(eval_id) is None
+        # The operator's typed value is preserved on re-render.
+        assert "file:///eval.md" in resp.text
+
+    def test_file_uri_nonexistent_rejected(
+        self,
+        signed_in_client: TestClient,
+        store: InMemoryStore,
+        artifacts_dir: Path,
+    ) -> None:
+        """A ``file://`` URI inside the jail but pointing at a file that
+        does not exist is also rejected at submit time.
+        """
+        eval_id, _, _ = seed_evaluate_task(store)
+        csrf = self._claim(signed_in_client, eval_id)
+        ghost = artifacts_dir / "ghost.md"  # never created
+        resp = _post_form(
+            signed_in_client,
+            f"/evaluator/{eval_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("metric.score", "0.5"),
+                ("artifacts_uri", f"file://{ghost}"),
+            ],
+        )
+        assert resp.status_code == 400
+        assert "artifacts_uri does not exist" in resp.text
+        assert store.read_submission(eval_id) is None
+
+    def test_file_uri_readable_under_artifacts_dir_accepted(
+        self,
+        signed_in_client: TestClient,
+        store: InMemoryStore,
+        artifacts_dir: Path,
+    ) -> None:
+        """The happy-path: a ``file://`` URI to a real, readable file
+        inside ``artifacts_dir`` is accepted and the submission lands
+        with the supplied URI.
+        """
+        eval_id, variant_id, _ = seed_evaluate_task(store)
+        artifact = artifacts_dir / "eval-log.md"
+        artifact.write_text("# eval log\n")
+        csrf = self._claim(signed_in_client, eval_id)
+        resp = _post_form(
+            signed_in_client,
+            f"/evaluator/{eval_id}/submit",
+            [
+                ("csrf_token", csrf),
+                ("status", "success"),
+                ("metric.score", "0.75"),
+                ("artifacts_uri", f"file://{artifact}"),
+            ],
+        )
+        assert resp.status_code == 200
+        recorded = get_evaluate_submission(store, eval_id)
+        assert recorded.status == "success"
+        assert recorded.variant_id == variant_id
+        assert recorded.artifacts_uri == f"file://{artifact}"
 
 
 class TestIntegerWireForm:


### PR DESCRIPTION
## Summary

- The web-ui evaluator draft form silently accepted any string in the optional `artifacts_uri` input. Discovered in the 2026-05-22 manual demo: an operator typed `file:///eval.md`, the submission stored that URI verbatim, and the resulting `/artifacts?uri=...` 404'd later. Per spec §4.2 the bad URI was locked in (resubmit equivalence does not include `artifacts_uri`).
- Validate at submit time in `routes/evaluator.py`: if `draft.artifacts_uri` parses to a `file://` URI, require it to (a) resolve under the configured `artifacts_dir` jail, (b) exist, (c) be a regular file, (d) be readable. On failure, re-render the draft form with an inline `artifacts_uri` field error and the operator's typed value preserved.
- Non-`file://` schemes (`http`/`https`) pass through unchanged — the substrate can't probe remote URIs server-side and the template already renders them as links. The existing `test_success_records_metric` (which submits an `https://...` URI) still passes.
- Adjacent template improvements per the issue: `placeholder`/`title` showing the canonical container path shape, plus a `<small>` help line clarifying file:// vs http(s).

## Implementation notes

- New helper `validate_file_artifact_uri(uri, artifacts_dir)` in `routes/_helpers.py` returns `None` on accept or an operator-facing error string. The helper mirrors the existing `_read_inline_artifact` jail-confinement logic but separates the "is it valid?" question from "render its content" so the submit handler can surface a *specific* reason (outside-jail vs nonexistent vs non-file).
- New helper `_parse_and_validate_evaluate_form(form, evaluation_schema, artifacts_dir)` in `routes/evaluator.py` combines `parse_evaluate_form` + URI validation behind one call. Keeps `submit()` flat; the second re-render branch I would have otherwise added pushed `submit` past the 100-line complexity-gate threshold.

## What this does NOT cover

- **Wire-level validation** (the load-bearing fix). The task-store-server's `POST /v0/experiments/<id>/evaluations` still accepts any `artifacts_uri`, so a direct wire client (CLI, conformance harness, a future non-reference UI) can still submit a bad URI. The proper-upload UX in #120 replaces the file-URI input entirely, so deferring the wire-level check there avoids building a check that the upload work will remove. This PR is the manual-UI stopgap.
- **Ideator form parallel check.** Issue #167 mentions the ideator form has "its own content-as-artifact mechanism; less affected but worth a parallel check." The ideator writes artifact files server-side from operator-supplied content, so the failure mode is different — outside this PR's scope.
- **First-write-wins spec discussion.** The issue notes the lock-in behavior is its own design question (whether `artifacts_uri` should be in the resubmit equivalence formula). Spec-level discussion deferred; this PR makes the bad URI unreachable from the UI in the first place.

## Fresh-operator walkthrough

- [x] Manually verified the form re-renders with the field-level error for `file:///eval.md` and that the typed value is preserved, via the new pytest at `test_file_uri_outside_artifacts_dir_rejected` (which drives the live route through TestClient and asserts on the rendered HTML). Live-browser smoke not run — pure route-side change with deterministic test coverage.
- [x] Notes: 24/24 evaluator route tests pass; 510/510 web-ui tests pass; 1773/1773 full reference tests pass.

## Test plan

- [x] `uv run ruff check .` (clean for web-ui)
- [x] `uv run pyright reference/services/web-ui/...` (0 errors)
- [x] `uv run pytest -q reference/services/web-ui/tests/` (510 passed)
- [x] `uv run pytest -q` (1773 passed, 216 skipped)
- [x] `npx --yes markdownlint-cli2@0.14.0 ...` (0 errors — no markdown changed)
- [x] `python3 scripts/check-rename-discipline.py` (clean)
- [x] `uv run python3 scripts/check-complexity.py` (clean — no new violations)
- [ ] Compose smoke (`smoke.sh` etc.) — not affected; pure route-side change

## Related issues

- Closes #167 — Web UI evaluator form: validate artifacts_uri at submit
- Refs #120 — multi-file uploads (proper replacement; wire-level check deferred here)
- Refs #134 — Pydantic ValidationError → form re-render (sibling form-error work; current PR #190 not yet merged so we did not rebase against it — the two share no overlapping diff hunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)