### PR TITLE
Fix #142: setup-experiment --no-auto-host-workers opt-out

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -115,6 +115,7 @@ Flags (all optional except the positional config):
 | `--ideas-per-ideation <N>` | `1` | How many ideas each subprocess-mode ideation task asks for. |
 | `--exec-mode host\|docker` | `host` | `docker` wraps each subprocess-mode `*_command` in a sibling container via DooD (host docker socket). |
 | `--seed-from <host-dir>` | empty seed | See above. |
+| `--no-auto-host-workers` | off (auto-hosts pre-registered) | Skip pre-registering the `ideator-1` / `executor-1` / `evaluator-1` worker IDs in the registry. Use when running a fully-manual experiment where the auto-host services won't come up — avoids phantom workers in `/admin/workers/`. Tradeoff: reassigning a task to one of those worker IDs returns `error=unknown-target` until the corresponding host self-registers (which never happens in fully-manual flows). The manual-UI wrapper (`eden-experiment up` without `--with-workers`) passes this automatically. |
 
 Re-running setup is **idempotent**: existing secrets (`EDEN_ADMIN_TOKEN`, `POSTGRES_PASSWORD`, `EDEN_SESSION_SECRET`, `FORGEJO_*`) are read back from `.env` and preserved. Run it again to pick up config edits.
 

--- a/reference/scripts/manual-ui/eden-experiment
+++ b/reference/scripts/manual-ui/eden-experiment
@@ -170,6 +170,15 @@ cmd_up() {
         [[ -d "$seed_from" ]] || die "--seed-from path is not a directory: $seed_from"
         setup_args+=(--seed-from "$seed_from")
     fi
+    # Manual-UI default is NON_WORKER_SERVICES only — the auto-host
+    # workers (ideator-1 / executor-1 / evaluator-1) won't come up,
+    # so skip pre-registering them in the worker registry (issue #142).
+    # When --with-workers is set, fall back to the default
+    # pre-registration so the wave-5 reassign-route unknown-target
+    # check has a populated registry to validate against.
+    if [[ -z "$with_workers" ]]; then
+        setup_args+=(--no-auto-host-workers)
+    fi
     echo "--- running setup-experiment ---" >&2
     bash "$SETUP_SCRIPT" "${setup_args[@]}"
 

--- a/reference/scripts/setup-experiment/setup-experiment.sh
+++ b/reference/scripts/setup-experiment/setup-experiment.sh
@@ -34,6 +34,7 @@ Usage:
                       [--ideas-per-ideation <N>]
                       [--exec-mode {host,docker}]
                       [--seed-from <host-dir>]
+                      [--no-auto-host-workers]
 
 Generates `reference/compose/.env` and copies <config.yaml> to
 `reference/compose/experiment-config.yaml`, then seeds the bare
@@ -83,6 +84,7 @@ ARG_IDEAS_PER_IDEATION=""
 ARG_EXEC_MODE="host"
 ARG_SEED_FROM=""
 ARG_DATA_ROOT=""
+ARG_NO_AUTO_HOST_WORKERS=""
 
 require_value() {
     # Validate that a flag's value is present, since `set -u` would
@@ -107,6 +109,7 @@ while [[ $# -gt 0 ]]; do
         --exec-mode)            require_value "$1" "$#"; ARG_EXEC_MODE="$2";         shift 2 ;;
         --seed-from)            require_value "$1" "$#"; ARG_SEED_FROM="$2";         shift 2 ;;
         --data-root)            require_value "$1" "$#"; ARG_DATA_ROOT="$2";         shift 2 ;;
+        --no-auto-host-workers) ARG_NO_AUTO_HOST_WORKERS="1";                        shift ;;
         -h|--help)              usage; exit 0 ;;
         --*)                    echo "unknown flag: $1" >&2; usage; exit 2 ;;
         *)
@@ -778,16 +781,29 @@ esac
 # The set of worker_ids is the reference deployment's known shape;
 # operators with different worker_id schemes register theirs the same
 # way (admin-gated POST /workers).
-for wid in ideator-1 executor-1 evaluator-1; do
-    rc=$(bootstrap_curl POST "${EXP_BASE}/workers" \
-        "{\"worker_id\":\"${wid}\"}")
-    case "$rc" in
-        200) ;;
-        *) echo "register_worker(${wid}) failed: http=$rc" >&2; exit 1 ;;
-    esac
-done
+#
+# --no-auto-host-workers skips this block for fully-manual experiments
+# that won't run the auto-host services (`compose up` without the
+# *_host services). Tradeoff: without pre-registration, an operator
+# who later reassigns a task to one of these auto-host worker_ids
+# *before* that host has self-registered will get the reassign route's
+# `error=unknown-target`; for fully-manual flows that's the right
+# failure mode (the host isn't coming).
+if [[ -z "$ARG_NO_AUTO_HOST_WORKERS" ]]; then
+    for wid in ideator-1 executor-1 evaluator-1; do
+        rc=$(bootstrap_curl POST "${EXP_BASE}/workers" \
+            "{\"worker_id\":\"${wid}\"}")
+        case "$rc" in
+            200) ;;
+            *) echo "register_worker(${wid}) failed: http=$rc" >&2; exit 1 ;;
+        esac
+    done
+    bootstrap_summary="worker hosts pre-registered"
+else
+    bootstrap_summary="auto-host workers NOT pre-registered (--no-auto-host-workers)"
+fi
 
-echo "--- bootstrap complete: admins + orchestrators groups; initial admin = ${EDEN_ADMINS_INITIAL_MEMBER}; web-ui admin = ${EDEN_WEB_UI_WORKER_ID}; worker hosts pre-registered ---" >&2
+echo "--- bootstrap complete: admins + orchestrators groups; initial admin = ${EDEN_ADMINS_INITIAL_MEMBER}; web-ui admin = ${EDEN_WEB_UI_WORKER_ID}; ${bootstrap_summary} ---" >&2
 
 # If the operator passed a custom --env-file path, echo a
 # next-step that uses an absolute path so they don't have to


### PR DESCRIPTION
Closes #142. Interim fix.

## Summary

- Adds `--no-auto-host-workers` to `setup-experiment.sh` (Option A from the issue: explicit opt-out, default behavior unchanged).
- `eden-experiment up` auto-passes the flag when `--with-workers` is absent — the manual-UI wrapper already brings up only `NON_WORKER_SERVICES`, so registering the auto-host worker IDs creates phantom rows that confuse `/admin/workers/`. With `--with-workers` it falls back to the pre-registration default.
- Documents the flag + the reassign-route tradeoff in `docs/user-guide.md` §2 and in an inline comment around the new conditional.

## What this does NOT cover

- The deployment-level worker registry (#141). The interim fix stays useful when #141 lands.
- Lazy / on-first-connect registration. That's a design choice the issue explicitly defers to #141.
- Skill-side updates beyond the wrapper auto-pass. The `eden-manual-experiment` skill calls `\$EDEN_EXP up` and inherits the right default through the wrapper; no skill change needed.

## Test plan

- [ ] CI: lint + complexity-gate + rename-discipline pass.
- [ ] CI: `compose-smoke` job exercises the default path (auto-hosts pre-registered) end-to-end.
- [ ] Local manual: `setup-experiment.sh <config> --experiment-id test-142-default` — verify `ideator-1` / `executor-1` / `evaluator-1` present in `/workers` after bring-up.
- [ ] Local manual: `setup-experiment.sh <config> --experiment-id test-142-optout --no-auto-host-workers` — verify only `web-ui` worker is registered.
- [ ] Local manual: `eden-experiment up` (without `--with-workers`) — verify the wrapper passes `--no-auto-host-workers` through (stderr: `auto-host workers NOT pre-registered`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)