### PR TITLE
Fix #111: optional fixture-artifact emission in scripted hosts

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -68,7 +68,10 @@ Useful for: browsing branches (`work/*`, `variant/*`, `main`), diffing arbitrary
 
 Worker-emitted artifacts (idea content markdown, evaluation outputs) live under `${EDEN_EXPERIMENT_DATA_ROOT}/artifacts/` on the host. That directory is the same bind-mount the web-ui sees as `/var/lib/eden/artifacts/` — host path and container path are two views of the same bytes.
 
-**Important caveat — scripted mode produces no artifact files.** The default Compose deployment runs the worker hosts in **scripted** mode; the scripted ideator / executor / evaluator stamp `artifacts_uri = file:///tmp/artifacts/...` onto every submission but never write those files to disk. The strings are fictional pointers. To see real artifact files in this directory, run [subprocess mode](user-guide.md#3-worker-host-modes) (`-f compose.yaml -f compose.subprocess.yaml`) — only then do the user-supplied `*_command` workers emit real bytes under `/var/lib/eden/artifacts/`.
+**Important caveat — scripted mode produces no artifact files by default.** The default Compose deployment runs the worker hosts in **scripted** mode; the scripted ideator / executor / evaluator stamp `artifacts_uri = file:///tmp/artifacts/...` onto every submission but never write those files to disk. The strings are fictional pointers. Two ways to get real artifact files:
+
+- **Subprocess mode** ([`user-guide.md` §3](user-guide.md#3-worker-host-modes), `-f compose.yaml -f compose.subprocess.yaml`) — the user-supplied `*_command` workers emit real bytes under `/var/lib/eden/artifacts/`.
+- **Scripted mode with `--emit-fixture-artifacts`** (issue #111) — each scripted host (ideator / executor / evaluator) accepts an opt-in flag that writes small placeholder files under `--artifacts-dir` and stamps real `file:///var/lib/eden/artifacts/<path>` URIs onto submissions. Useful for demos / onboarding where the artifacts substrate should be observable without an experiment config providing real worker code. Pair the flag with `--artifacts-dir` (the host's view of the same bind-mount the web-ui sees as `/var/lib/eden/artifacts/`).
 
 Three ways to read artifacts when they exist:
 

--- a/reference/packages/eden-dispatch/src/eden_dispatch/workers.py
+++ b/reference/packages/eden-dispatch/src/eden_dispatch/workers.py
@@ -50,6 +50,7 @@ class ExecutionOutcome:
     commit_sha: str | None = None
     branch: str | None = None
     description: str | None = None
+    artifacts_uri: str | None = None
 
 
 @dataclass(frozen=True)
@@ -214,6 +215,8 @@ class ScriptedExecutor:
         }
         if outcome.description is not None:
             variant_kwargs["description"] = outcome.description
+        if outcome.artifacts_uri is not None:
+            variant_kwargs["artifacts_uri"] = outcome.artifacts_uri
         variant = Variant(**variant_kwargs)
         store.create_variant(variant)
         store.submit(

--- a/reference/services/_common/src/eden_service_common/scripted.py
+++ b/reference/services/_common/src/eden_service_common/scripted.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from eden_contracts import (
@@ -43,25 +44,74 @@ _IMPL_IDENTITY = Identity(
 )
 _IMPL_DATE = "2026-04-01T00:00:00+00:00"
 
+# Canonical URI prefix the Compose web-ui bind-mounts the artifacts
+# substrate at. Real fixture files are written under
+# ``--artifacts-dir`` (the worker host's view of the same bytes) and
+# stamped onto submissions with this URI prefix so the web-ui's
+# ``/artifacts?uri=...`` route resolves them to the bind-mount.
+_FIXTURE_URI_PREFIX = "file:///var/lib/eden/artifacts"
+
+
+def _emit_fixture(
+    artifacts_dir: Path | None,
+    relative_path: str,
+    body: str,
+    *,
+    fallback_uri: str,
+) -> str:
+    """Write a fixture placeholder file and return its ``file://`` URI.
+
+    When ``artifacts_dir`` is ``None`` the helper is a no-op and
+    returns ``fallback_uri`` unchanged — that's the default-OFF mode
+    that preserves the historical fictional ``file:///tmp/artifacts/...``
+    pointers existing tests + smoke baselines depend on.
+    """
+    if artifacts_dir is None:
+        return fallback_uri
+    target = Path(artifacts_dir) / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+    return f"{_FIXTURE_URI_PREFIX}/{relative_path}"
+
 
 def make_plan_fn(
-    *, base_commit_sha: str, ideas_per_ideation: int = 1
+    *,
+    base_commit_sha: str,
+    ideas_per_ideation: int = 1,
+    artifacts_dir: Path | None = None,
 ) -> ScriptedPlanFn:
     """Build a ideation_fn that drafts ``ideas_per_ideation`` ideas per ideation task.
 
     Each idea carries ``parent_commits=(base_commit_sha,)``,
     satisfying the schema's ``min_length=1`` constraint.
+
+    When ``artifacts_dir`` is set, write a placeholder content file
+    per idea-template under ``ideas/<task_id>/<i>/content.txt`` and
+    stamp the matching ``file:///var/lib/eden/artifacts/...`` URI
+    onto the template; ``None`` (the default) preserves the
+    historical ``file:///tmp/artifacts/...`` fictional pointer.
     """
 
     def _plan(task: IdeationTask) -> list[IdeaTemplate]:
         templates: list[IdeaTemplate] = []
         for i in range(ideas_per_ideation):
+            relative = f"ideas/{task.task_id}/{i}/content.txt"
+            body = (
+                f"Fixture idea content for {task.task_id}, slot {i}.\n"
+                "A real ideator would emit the idea's rationale / prompt / blueprint here.\n"
+            )
+            uri = _emit_fixture(
+                artifacts_dir,
+                relative,
+                body,
+                fallback_uri=f"file:///tmp/artifacts/{task.task_id}/{i}",
+            )
             templates.append(
                 IdeaTemplate(
                     slug=f"{task.task_id}-p{i}",
                     priority=float(ideas_per_ideation - i),
                     parent_commits=(base_commit_sha,),
-                    artifacts_uri=f"file:///tmp/artifacts/{task.task_id}/{i}",
+                    artifacts_uri=uri,
                 )
             )
         return templates
@@ -70,7 +120,10 @@ def make_plan_fn(
 
 
 def make_implement_fn(
-    *, repo_path: str, fail_every: int | None = None
+    *,
+    repo_path: str,
+    fail_every: int | None = None,
+    artifacts_dir: Path | None = None,
 ) -> ScriptedImplementFn:
     """Build an execution_fn that writes a real git commit per task.
 
@@ -81,6 +134,13 @@ def make_implement_fn(
 
     ``fail_every``, if set, returns ``status=error`` for every Nth
     task (1-indexed); useful for exercising rejection paths.
+
+    When ``artifacts_dir`` is set, write a placeholder notes file
+    under ``variants/<variant_id>/notes.txt`` and stamp the matching
+    URI onto the outcome (propagated to the Variant by
+    ``ScriptedExecutor``); ``None`` (the default) leaves
+    ``ExecutionOutcome.artifacts_uri`` unset, matching the
+    historical scripted behavior.
     """
     counter = itertools.count(1)
 
@@ -130,17 +190,35 @@ def make_implement_fn(
                         expected_old_sha=commit_sha,
                     )
                 return ExecutionOutcome(status="error")
+        artifacts_uri: str | None = None
+        if artifacts_dir is not None:
+            relative = f"variants/{variant_id}/notes.txt"
+            body = (
+                f"Fixture executor notes for {variant_id} "
+                f"(idea slug: {idea.slug!r}).\n"
+                "A real executor would emit build logs / diffs / rationale here.\n"
+            )
+            artifacts_uri = _emit_fixture(
+                artifacts_dir,
+                relative,
+                body,
+                fallback_uri="",  # unreachable: artifacts_dir is not None
+            )
         return ExecutionOutcome(
             status="success",
             commit_sha=commit_sha,
             branch=branch_short,
+            artifacts_uri=artifacts_uri,
         )
 
     return _implement
 
 
 def make_evaluate_fn(
-    *, evaluation_schema: EvaluationSchema, fail_every: int | None = None
+    *,
+    evaluation_schema: EvaluationSchema,
+    fail_every: int | None = None,
+    artifacts_dir: Path | None = None,
 ) -> ScriptedEvaluateFn:
     """Build an evaluation_fn that emits deterministic metrics.
 
@@ -150,15 +228,32 @@ def make_evaluate_fn(
 
     ``fail_every``, if set, returns ``status=error`` for every Nth
     task (1-indexed).
+
+    When ``artifacts_dir`` is set, write a placeholder evaluation
+    file under ``evaluations/<variant_id>/evaluation.txt`` and stamp
+    the matching URI onto the outcome; ``None`` (the default)
+    preserves the historical ``file:///tmp/artifacts/<variant_id>``
+    fictional pointer.
     """
     counter = itertools.count(1)
 
     def _evaluate(task: EvaluationTask, variant: Variant) -> EvaluationOutcome:
         index = next(counter)
+        relative = f"evaluations/{variant.variant_id}/evaluation.txt"
+        body = (
+            f"Fixture evaluation output for {variant.variant_id}.\n"
+            "A real evaluator would emit metric traces / plots / logs here.\n"
+        )
+        artifacts_uri = _emit_fixture(
+            artifacts_dir,
+            relative,
+            body,
+            fallback_uri=f"file:///tmp/artifacts/{variant.variant_id}",
+        )
         if fail_every is not None and fail_every > 0 and index % fail_every == 0:
             return EvaluationOutcome(
                 status="error",
-                artifacts_uri=f"file:///tmp/artifacts/{variant.variant_id}",
+                artifacts_uri=artifacts_uri,
             )
         evaluation: dict[str, Any] = {}
         for name, kind in evaluation_schema.root.items():
@@ -166,7 +261,7 @@ def make_evaluate_fn(
         return EvaluationOutcome(
             status="success",
             evaluation=evaluation,
-            artifacts_uri=f"file:///tmp/artifacts/{variant.variant_id}",
+            artifacts_uri=artifacts_uri,
         )
 
     return _evaluate

--- a/reference/services/evaluator/src/eden_evaluator_host/cli.py
+++ b/reference/services/evaluator/src/eden_evaluator_host/cli.py
@@ -37,7 +37,7 @@ from .subprocess_mode import (
 )
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # slop-allow: argparse builder; one add_argument per CLI flag with no branching, plus mode-specific validation at the end; splitting fragments the flat flag manifest without reducing logic.
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: E501  # slop-allow: argparse builder; one add_argument per CLI flag with no branching, plus mode-specific validation at the end; splitting fragments the flat flag manifest without reducing logic.
     """Parse CLI args for the evaluator host."""
     parser = argparse.ArgumentParser(
         prog="eden-evaluator-host",

--- a/reference/services/evaluator/src/eden_evaluator_host/cli.py
+++ b/reference/services/evaluator/src/eden_evaluator_host/cli.py
@@ -37,7 +37,7 @@ from .subprocess_mode import (
 )
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # slop-allow: argparse builder; one add_argument per CLI flag with no branching, plus mode-specific validation at the end; splitting fragments the flat flag manifest without reducing logic.
     """Parse CLI args for the evaluator host."""
     parser = argparse.ArgumentParser(
         prog="eden-evaluator-host",
@@ -62,6 +62,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--fail-every",
         type=int,
         default=None,
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        default=None,
+        help=(
+            "Scripted-mode only: where to write fixture artifact "
+            "files when --emit-fixture-artifacts is set."
+        ),
+    )
+    parser.add_argument(
+        "--emit-fixture-artifacts",
+        action="store_true",
+        help=(
+            "Scripted-mode only: write small placeholder fixture "
+            "files under --artifacts-dir and stamp real "
+            "file:///var/lib/eden/artifacts/... URIs onto "
+            "EvaluationSubmissions (instead of the default "
+            "fictional /tmp/artifacts/... pointers). See issue #111."
+        ),
     )
     # Subprocess-mode flags.
     parser.add_argument("--experiment-dir", default=None)
@@ -112,6 +131,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                 parser.error(
                     f"--{attr.replace('_', '-')} is required in --mode subprocess"
                 )
+        if args.emit_fixture_artifacts:
+            parser.error(
+                "--emit-fixture-artifacts is scripted-mode only "
+                "(subprocess mode emits real artifacts via the user-supplied "
+                "evaluation_command)"
+            )
+    else:
+        if args.emit_fixture_artifacts and args.artifacts_dir is None:
+            parser.error(
+                "--artifacts-dir is required when --emit-fixture-artifacts is set"
+            )
     return args
 
 
@@ -230,6 +260,11 @@ def main(argv: list[str] | None = None) -> int:
         bearer=bearer,
     ) as client:
         if args.mode == "scripted":
+            scripted_artifacts_dir = (
+                Path(args.artifacts_dir)
+                if args.emit_fixture_artifacts and args.artifacts_dir is not None
+                else None
+            )
             run_evaluator_loop(
                 store=client,
                 worker_id=args.worker_id,
@@ -237,6 +272,7 @@ def main(argv: list[str] | None = None) -> int:
                 fail_every=args.fail_every,
                 poll_interval=args.poll_interval,
                 stop=stop,
+                artifacts_dir=scripted_artifacts_dir,
             )
         else:
             _run_subprocess_mode(

--- a/reference/services/evaluator/src/eden_evaluator_host/host.py
+++ b/reference/services/evaluator/src/eden_evaluator_host/host.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from eden_contracts import EvaluationSchema
 from eden_dispatch import ScriptedEvaluator
 from eden_service_common import StopFlag, get_logger, make_evaluate_fn
@@ -18,16 +20,27 @@ def run_evaluator_loop(
     fail_every: int | None,
     poll_interval: float,
     stop: StopFlag,
+    artifacts_dir: Path | None = None,
 ) -> None:
     """Poll for pending evaluation tasks and drive each through the scripted profile.
 
     Returns only when ``stop`` is set.
+
+    ``artifacts_dir`` (when set) opts into fixture-artifact emission:
+    each evaluation writes a placeholder file under
+    ``evaluations/<variant_id>/evaluation.txt`` and stamps a real
+    ``file:///var/lib/eden/artifacts/...`` URI onto the
+    EvaluationSubmission. ``None`` (the default) preserves the
+    historical fictional ``file:///tmp/artifacts/...`` pointer.
     """
+    if artifacts_dir is not None:
+        Path(artifacts_dir).mkdir(parents=True, exist_ok=True)
     evaluator = ScriptedEvaluator(
         worker_id=worker_id,
         evaluation_fn=make_evaluate_fn(
             evaluation_schema=evaluation_schema,
             fail_every=fail_every,
+            artifacts_dir=artifacts_dir,
         ),
     )
     while not stop.is_set():

--- a/reference/services/executor/src/eden_executor_host/cli.py
+++ b/reference/services/executor/src/eden_executor_host/cli.py
@@ -81,6 +81,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="If set, fail every Nth task (1-indexed). Default: never fail.",
     )
+    parser.add_argument(
+        "--artifacts-dir",
+        default=None,
+        help=(
+            "Scripted-mode only: where to write fixture artifact "
+            "files when --emit-fixture-artifacts is set."
+        ),
+    )
+    parser.add_argument(
+        "--emit-fixture-artifacts",
+        action="store_true",
+        help=(
+            "Scripted-mode only: write small placeholder fixture "
+            "files under --artifacts-dir and stamp real "
+            "file:///var/lib/eden/artifacts/... URIs onto Variant "
+            "records (default OFF preserves the historical "
+            "no-per-variant-artifacts behavior). See issue #111."
+        ),
+    )
     # Subprocess-mode flags.
     parser.add_argument("--experiment-config", default=None)
     parser.add_argument("--experiment-dir", default=None)
@@ -102,6 +121,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                 parser.error(
                     f"--{attr.replace('_', '-')} is required in --mode subprocess"
                 )
+        if args.emit_fixture_artifacts:
+            parser.error(
+                "--emit-fixture-artifacts is scripted-mode only "
+                "(subprocess mode emits real artifacts via the user-supplied "
+                "execution_command)"
+            )
+    else:
+        if args.emit_fixture_artifacts and args.artifacts_dir is None:
+            parser.error(
+                "--artifacts-dir is required when --emit-fixture-artifacts is set"
+            )
     return args
 
 
@@ -139,6 +169,11 @@ def main(argv: list[str] | None = None) -> int:
         bearer=bearer,
     ) as client:
         if args.mode == "scripted":
+            scripted_artifacts_dir = (
+                Path(args.artifacts_dir)
+                if args.emit_fixture_artifacts and args.artifacts_dir is not None
+                else None
+            )
             run_executor_loop(
                 store=client,
                 worker_id=args.worker_id,
@@ -146,6 +181,7 @@ def main(argv: list[str] | None = None) -> int:
                 fail_every=args.fail_every,
                 poll_interval=args.poll_interval,
                 stop=stop,
+                artifacts_dir=scripted_artifacts_dir,
             )
         else:
             config = load_experiment_config(args.experiment_config)

--- a/reference/services/executor/src/eden_executor_host/host.py
+++ b/reference/services/executor/src/eden_executor_host/host.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 
 from eden_dispatch import ScriptedExecutor
 from eden_service_common import StopFlag, get_logger, make_implement_fn
@@ -30,15 +31,27 @@ def run_executor_loop(
     fail_every: int | None,
     poll_interval: float,
     stop: StopFlag,
+    artifacts_dir: Path | None = None,
 ) -> None:
     """Poll for pending execution tasks and drive each through the scripted profile.
 
     Returns only when ``stop`` is set.
+
+    ``artifacts_dir`` (when set) opts into fixture-artifact emission:
+    each successful execution writes a placeholder file under
+    ``variants/<variant_id>/notes.txt`` and stamps a real
+    ``file:///var/lib/eden/artifacts/...`` URI onto the Variant.
+    ``None`` (the default) preserves the historical scripted
+    behavior (no per-variant ``artifacts_uri``, no files written).
     """
+    if artifacts_dir is not None:
+        Path(artifacts_dir).mkdir(parents=True, exist_ok=True)
     impl = ScriptedExecutor(
         worker_id=worker_id,
         execution_fn=make_implement_fn(
-            repo_path=repo_path, fail_every=fail_every
+            repo_path=repo_path,
+            fail_every=fail_every,
+            artifacts_dir=artifacts_dir,
         ),
         variant_id_factory=_variant_id,
         now=_now_iso,

--- a/reference/services/ideator/src/eden_ideator_host/cli.py
+++ b/reference/services/ideator/src/eden_ideator_host/cli.py
@@ -39,7 +39,7 @@ from .host import (
 )
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # slop-allow: argparse builder; one add_argument per CLI flag with no branching, plus mode-specific validation at the end; splitting fragments the flat flag manifest without reducing logic.
     """Parse CLI args for the ideator host."""
     parser = argparse.ArgumentParser(
         prog="eden-ideator-host",
@@ -81,7 +81,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--artifacts-dir",
         default=None,
-        help="Where to write content artifacts (required in --mode subprocess).",
+        help=(
+            "Where to write content artifacts. Required in --mode "
+            "subprocess. In --mode scripted, required only when "
+            "--emit-fixture-artifacts is set."
+        ),
+    )
+    parser.add_argument(
+        "--emit-fixture-artifacts",
+        action="store_true",
+        help=(
+            "Scripted-mode only: write small placeholder fixture "
+            "files under --artifacts-dir and stamp real "
+            "file:///var/lib/eden/artifacts/... URIs onto submissions "
+            "(instead of the default fictional /tmp/artifacts/... "
+            "pointers). See issue #111."
+        ),
     )
     # 12a-1f git substrate: optional clone-on-startup wiring mirroring
     # executor / evaluator. Subprocess-mode only — scripted-mode
@@ -132,12 +147,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         if not args.base_commit_sha:
             parser.error("--base-commit-sha is required in --mode scripted")
         _validate_sha(args.base_commit_sha)
+        if args.emit_fixture_artifacts and args.artifacts_dir is None:
+            parser.error(
+                "--artifacts-dir is required when --emit-fixture-artifacts is set"
+            )
     else:
         for attr in ("experiment_config", "experiment_dir", "artifacts_dir"):
             if getattr(args, attr) is None:
                 parser.error(
                     f"--{attr.replace('_', '-')} is required in --mode subprocess"
                 )
+        if args.emit_fixture_artifacts:
+            parser.error(
+                "--emit-fixture-artifacts is scripted-mode only "
+                "(subprocess mode emits real artifacts via the user-supplied "
+                "ideation_command)"
+            )
     return args
 
 
@@ -370,6 +395,11 @@ def main(argv: list[str] | None = None) -> int:
         bearer=bearer,
     ) as client:
         if args.mode == "scripted":
+            scripted_artifacts_dir = (
+                Path(args.artifacts_dir)
+                if args.emit_fixture_artifacts and args.artifacts_dir is not None
+                else None
+            )
             run_ideator_loop(
                 store=client,
                 worker_id=args.worker_id,
@@ -377,6 +407,7 @@ def main(argv: list[str] | None = None) -> int:
                 ideas_per_ideation=args.ideas_per_ideation,
                 poll_interval=args.poll_interval,
                 stop=stop,
+                artifacts_dir=scripted_artifacts_dir,
             )
         else:
             _run_subprocess_mode(

--- a/reference/services/ideator/src/eden_ideator_host/cli.py
+++ b/reference/services/ideator/src/eden_ideator_host/cli.py
@@ -39,7 +39,7 @@ from .host import (
 )
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # slop-allow: argparse builder; one add_argument per CLI flag with no branching, plus mode-specific validation at the end; splitting fragments the flat flag manifest without reducing logic.
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:  # noqa: E501  # slop-allow: argparse builder; one add_argument per CLI flag with no branching, plus mode-specific validation at the end; splitting fragments the flat flag manifest without reducing logic.
     """Parse CLI args for the ideator host."""
     parser = argparse.ArgumentParser(
         prog="eden-ideator-host",

--- a/reference/services/ideator/src/eden_ideator_host/host.py
+++ b/reference/services/ideator/src/eden_ideator_host/host.py
@@ -42,18 +42,30 @@ def run_ideator_loop(
     ideas_per_ideation: int,
     poll_interval: float,
     stop: StopFlag,
+    artifacts_dir: Path | None = None,
 ) -> None:
     """Poll for pending ideation tasks and drive each through the scripted profile.
 
     Returns only when ``stop`` is set. If no pending tasks are visible,
     waits ``poll_interval`` seconds between polls; drains bursts without
     sleeping.
+
+    ``artifacts_dir`` (when set) opts into fixture-artifact emission:
+    each emitted idea-template writes a placeholder file under
+    ``ideas/<task_id>/<i>/content.txt`` and stamps a real
+    ``file:///var/lib/eden/artifacts/...`` URI onto the Idea.
+    ``None`` (the default) preserves the historical scripted
+    behavior (fictional ``file:///tmp/artifacts/...`` pointer, no
+    files written).
     """
+    if artifacts_dir is not None:
+        Path(artifacts_dir).mkdir(parents=True, exist_ok=True)
     ideator = ScriptedIdeator(
         worker_id=worker_id,
         ideation_fn=make_plan_fn(
             base_commit_sha=base_commit_sha,
             ideas_per_ideation=ideas_per_ideation,
+            artifacts_dir=artifacts_dir,
         ),
         idea_id_factory=_idea_id,
         now=_now_iso,


### PR DESCRIPTION
## Summary

- Add opt-in `--emit-fixture-artifacts` + `--artifacts-dir` flag pair to each scripted worker host (ideator / executor / evaluator). When set, write a small placeholder file per emitted idea / variant / evaluation and stamp the real `file:///var/lib/eden/artifacts/<path>` URI onto the corresponding submission — replacing the fictional `file:///tmp/artifacts/...` strings the scripted hosts have always stamped.
- Default OFF preserves bit-for-bit the historical scripted behavior (fictional URIs, no files written), so CI smoke + conformance baselines are unaffected.
- Makes the artifacts substrate observable in scripted-mode demos / onboarding without requiring an experiment config to provide real worker code (subprocess mode's prerequisite). Pairs with #107 (artifacts listing endpoint).

Mechanism:

- `make_plan_fn` / `make_implement_fn` / `make_evaluate_fn` in `reference/services/_common/src/eden_service_common/scripted.py` accept an optional `artifacts_dir: Path | None`; when set they write a placeholder file under `<artifacts_dir>/{ideas,variants,evaluations}/<id>/...` and return a `file:///var/lib/eden/artifacts/...` URI.
- `ExecutionOutcome` gains an `artifacts_uri` field that `ScriptedExecutor` propagates onto the Variant when set.
- Each host CLI registers the flag pair and threads `artifacts_dir` into its scripted-loop entry point only when both `--emit-fixture-artifacts` and `--mode scripted` are active. Subprocess mode rejects the flag (real artifacts come from the user-supplied `*_command`).

## What this does NOT cover

- Compose-stack wiring (`compose.yaml` env-var-gated default ON for the demo stack) — deferred; this PR ships the flag plumbing only. The web-ui's artifacts route resolves the new URIs unchanged (they sit under `/var/lib/eden/artifacts/` like real ones).
- Realistic artifact content (LLM-generated rationale, non-trivial commit diffs) — explicitly out of scope per the issue; fixtures are obviously synthetic two-line placeholders.

## Fresh-operator walkthrough

N/A — these CLI flags are opt-in and default OFF; no operator-facing surface behavior changes for the existing Compose-stack walkthrough. A future PR that flips the demo stack to `--emit-fixture-artifacts` ON will own the walkthrough.

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run pyright` — 0 errors / 0 warnings
- [x] `uv run pytest -q reference/` — 1771 passed, 216 skipped (full reference suite; default-OFF preserves baselines)
- [x] `uv run pytest -q conformance/` — 247 passed, 11 skipped
- [x] `python3 scripts/check-complexity.py` — passes (added `# slop-allow:` to ideator + evaluator `parse_args` argparse builders that now cross the 100-line threshold; standard argparse-builder justification)
- [x] `npx markdownlint-cli2@0.14.0 docs/observability.md` — passes
- [x] Manual smoke (Python REPL): default behavior emits the historical `file:///tmp/artifacts/...` URIs and writes no files; `--emit-fixture-artifacts` with an `artifacts_dir` writes the expected three placeholder files and stamps `file:///var/lib/eden/artifacts/...` URIs.

## Related issues

- Closes #111 — Optional fixture-artifact emission in scripted worker hosts
- Refs #107 — Artifacts listing endpoint (together makes the artifacts substrate fully observable in scripted-mode demos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)