### PR TITLE
Fix #121: slug uniqueness soft-check on idea submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Per-chunk entries preserve the full implementation record: contract amendments, 
 
 ## [Unreleased]
 
+### Slug-uniqueness soft-check on idea submission (issue #121)
+
+Polish item: when an operator submits an idea whose `slug` collides with an existing idea in the same experiment, the system now surfaces an advisory warning at submission time rather than silently accepting the collision. Slug uniqueness is **not** a protocol invariant — idea identity is by `idea_id` ([`spec/v0/02-data-model.md`](spec/v0/02-data-model.md) §5.1), and variant branches embed the unique `variant_id` so collisions are harmless in lineage tracking. The check is soft: the request still succeeds 200, and operators can deliberately reuse a slug (e.g., sibling variations grouped by slug) by ignoring the warning.
+
+**Spec amendment.** [`spec/v0/07-wire-protocol.md`](spec/v0/07-wire-protocol.md) §3 documents an OPTIONAL `warnings: list[string]` field on `create_idea`'s response body, alongside the idea fields per `idea.schema.json`. Warnings are non-normative diagnostic strings; implementations MAY omit the field, and clients MUST NOT rely on its presence or contents for correctness. (Conformance does NOT assert this field — it remains a reference-impl convenience.)
+
+**Wire layer.** [`reference/packages/eden-wire/src/eden_wire/server.py`](reference/packages/eden-wire/src/eden_wire/server.py)'s `_create_idea` calls a new module-level helper `_slug_conflict_warnings(store, idea)` that scans the experiment's existing ideas (`store.list_ideas()` is single-experiment scoped) for slug matches excluding the just-created idea. When matches are present, the response body grows a `warnings` array listing the colliding `idea_id` values; when none, the field is omitted (Pydantic-equivalent `exclude_none` semantics).
+
+**eden-manual CLI.** [`reference/scripts/manual-ui/eden-manual`](reference/scripts/manual-ui/eden-manual)'s `cmd_ideation_submit` now captures the `create_idea` response, prints any per-idea warning to stderr at creation time, and includes a `warnings` array in the final JSON output when any collisions were detected.
+
+**Web UI ideator.** The web-ui's `submit_idea` route (`reference/services/web-ui/src/eden_web_ui/routes/ideator.py`) doesn't go through the wire — it calls `store.create_idea` directly — so `_persist_idea_drafts` now performs the same slug scan locally and returns a `slug_warnings` list alongside the `idea_ids`. Warnings are passed through to `_render_submitted` and rendered as a `<div class="slug-warnings" role="alert">` block on [`ideator_submitted.html`](reference/services/web-ui/src/eden_web_ui/templates/ideator_submitted.html). Pre-submit AJAX validation (an alternative shape proposed in the issue) was deferred — the post-submit warning is sufficient for the polish goal and avoids the additional HTMX wiring.
+
+**Tests.** New `TestCreateIdeaSlugWarnings` class in [`reference/packages/eden-wire/tests/test_lifecycle_wire.py`](reference/packages/eden-wire/tests/test_lifecycle_wire.py) covers three cases: unique slug → no `warnings` key; duplicate slug → `warnings` array names the prior `idea_id`; triple-collision → all prior IDs listed. New `TestSlugSoftCheck` class in [`reference/services/web-ui/tests/test_ideator_flow.py`](reference/services/web-ui/tests/test_ideator_flow.py) asserts the warning block renders on the submitted page on collision and is absent on unique-slug submissions.
+
+**Out of scope (followups):** Pre-submit AJAX warning + confirmation step in the web-ui ideator form (the issue suggested this; deferred since the post-submit warning is sufficient and the form's HTMX surface is being reworked in adjacent issues — revisit if operator feedback shows the post-submit timing is too late). `docs/user-guide.md` §5 and `.claude/skills/eden-manual-ideator/SKILL.md` Phase 4 mentions of the soft-check are intentionally omitted since the warning is self-describing and the user-guide entry would just restate the behavior. Closes #121.
+
 ### Executor-host substrate access + DooD env-var forwarding (issues #154 + #155)
 
 Backfills two Phase 12a-1f deferrals together (single PR — both touch the DooD code path and are simpler to reason about as one change).

--- a/reference/packages/eden-wire/src/eden_wire/server.py
+++ b/reference/packages/eden-wire/src/eden_wire/server.py
@@ -904,11 +904,16 @@ def make_app(
         except ValidationError as exc:
             raise BadRequest(str(exc)) from exc
         store.create_idea(idea)
-        # §3: response body matches idea.schema.json; return the
-        # stored idea so the caller sees what landed.
-        return store.read_idea(idea.idea_id).model_dump(
+        # §3: response body is the idea per idea.schema.json with an
+        # OPTIONAL advisory `warnings` array (issue #121). Warnings are
+        # non-normative — clients MUST NOT rely on them for correctness.
+        body = store.read_idea(idea.idea_id).model_dump(
             mode="json", exclude_none=True
         )
+        warnings = _slug_conflict_warnings(store, idea)
+        if warnings:
+            body["warnings"] = warnings
+        return body
 
     @app.get(f"{base}/ideas")
     async def _list_ideas(
@@ -1869,6 +1874,27 @@ def _artifact_response_headers(path: str) -> dict[str, str]:
         "Content-Disposition": _build_content_disposition(raw_name),
         "X-Content-Type-Options": "nosniff",
     }
+
+
+def _slug_conflict_warnings(store: Store, idea: Idea) -> list[str]:
+    """Soft-check (issue #121): return advisory warnings for slug collisions.
+
+    Slug uniqueness is not a protocol invariant — idea identity is by
+    ``idea_id`` (spec/v0/02-data-model.md §5.1) and variant branches
+    embed the unique ``variant_id`` so collisions are harmless in
+    lineage. This helper surfaces collisions to operators at idea-
+    creation time so a duplicate slug isn't noticed only when browsing
+    ``/admin/ideas/``.
+    """
+    matches = [
+        other.idea_id
+        for other in store.list_ideas()
+        if other.slug == idea.slug and other.idea_id != idea.idea_id
+    ]
+    if not matches:
+        return []
+    quoted = ", ".join(f"{mid!r}" for mid in matches)
+    return [f"slug {idea.slug!r} is already used by idea(s) {quoted}"]
 
 
 def _submission_to_wire(submission: Submission) -> dict[str, Any]:

--- a/reference/packages/eden-wire/tests/test_lifecycle_wire.py
+++ b/reference/packages/eden-wire/tests/test_lifecycle_wire.py
@@ -615,3 +615,87 @@ class TestIntendedExecutorWireFlow:
         out = resp.json()
         # The store applied the idea's intended_executor to task.target.
         assert out["target"] == {"kind": "worker", "id": "executor-a"}
+
+
+# ----------------------------------------------------------------------
+# Slug-uniqueness soft-check on create_idea (issue #121)
+# ----------------------------------------------------------------------
+
+
+class TestCreateIdeaSlugWarnings:
+    """create_idea returns an advisory `warnings` array (issue #121)
+    when the submitted slug collides with an existing idea in the same
+    experiment. Slug uniqueness is not a protocol invariant — both
+    submissions still succeed 200.
+    """
+
+    def _post_idea(
+        self, client: TestClient, worker_id: str, token: str, *, idea_id: str, slug: str
+    ) -> httpx.Response:
+        return client.post(
+            f"/v0/experiments/{EXPERIMENT_ID}/ideas",
+            headers=_worker_headers(worker_id, token),
+            json={
+                "idea_id": idea_id,
+                "experiment_id": EXPERIMENT_ID,
+                "slug": slug,
+                "priority": 0.0,
+                "parent_commits": ["a" * 40],
+                "artifacts_uri": "s3://b/",
+                "state": "drafting",
+                "created_at": "2026-05-01T00:00:00Z",
+            },
+        )
+
+    def test_unique_slug_has_no_warnings(self, store: InMemoryStore) -> None:
+        app = make_app(store, admin_token=ADMIN_TOKEN)
+        client = TestClient(app)
+        token = _register_worker(client, "ideator-a")
+        resp = self._post_idea(
+            client, "ideator-a", token, idea_id="idea-1", slug="alpha"
+        )
+        assert resp.status_code == 200, resp.text
+        # No warnings key on the unique-slug submission.
+        assert "warnings" not in resp.json()
+
+    def test_duplicate_slug_returns_advisory_warning(
+        self, store: InMemoryStore
+    ) -> None:
+        app = make_app(store, admin_token=ADMIN_TOKEN)
+        client = TestClient(app)
+        token = _register_worker(client, "ideator-a")
+        first = self._post_idea(
+            client, "ideator-a", token, idea_id="idea-1", slug="alpha"
+        )
+        assert first.status_code == 200, first.text
+        assert "warnings" not in first.json()
+        second = self._post_idea(
+            client, "ideator-a", token, idea_id="idea-2", slug="alpha"
+        )
+        # Soft-check: second submission still succeeds.
+        assert second.status_code == 200, second.text
+        body = second.json()
+        assert body["idea_id"] == "idea-2"
+        assert "warnings" in body
+        joined = " ".join(body["warnings"])
+        assert "alpha" in joined
+        assert "idea-1" in joined
+
+    def test_warning_lists_all_prior_collisions(
+        self, store: InMemoryStore
+    ) -> None:
+        app = make_app(store, admin_token=ADMIN_TOKEN)
+        client = TestClient(app)
+        token = _register_worker(client, "ideator-a")
+        for n in (1, 2):
+            r = self._post_idea(
+                client, "ideator-a", token, idea_id=f"idea-{n}", slug="alpha"
+            )
+            assert r.status_code == 200, r.text
+        third = self._post_idea(
+            client, "ideator-a", token, idea_id="idea-3", slug="alpha"
+        )
+        assert third.status_code == 200
+        joined = " ".join(third.json()["warnings"])
+        assert "idea-1" in joined
+        assert "idea-2" in joined

--- a/reference/scripts/manual-ui/eden-manual
+++ b/reference/scripts/manual-ui/eden-manual
@@ -579,6 +579,7 @@ def cmd_ideation_submit(env: dict[str, str], args: argparse.Namespace) -> None:
     host_artifacts_dir = _host_artifacts_dir(env)
     host_artifacts_dir.mkdir(parents=True, exist_ok=True)
     idea_ids: list[str] = []
+    warnings: list[str] = []
 
     # Phase 1: create_idea as drafting for each.
     for raw in raw_ideas:
@@ -610,8 +611,16 @@ def cmd_ideation_submit(env: dict[str, str], args: argparse.Namespace) -> None:
             idea["intended_executor"] = raw["intended_executor"]
         if "intended_evaluator" in raw and raw["intended_evaluator"] is not None:
             idea["intended_evaluator"] = raw["intended_evaluator"]
-        _wire(env, f"/v0/experiments/{_exp(env)}/ideas", method="POST", body=idea, bearer=bearer)
+        resp = _wire(
+            env, f"/v0/experiments/{_exp(env)}/ideas",
+            method="POST", body=idea, bearer=bearer,
+        )
         idea_ids.append(idea_id)
+        # Soft-check (issue #121): wire may attach advisory `warnings`
+        # when the submitted slug collides with an existing idea.
+        for warning in (resp or {}).get("warnings", []) or []:
+            print(f"warning: idea {idea_id}: {warning}", file=sys.stderr)
+            warnings.append(f"{idea_id}: {warning}")
 
     # Phase 2: mark_ready for each.
     for iid in idea_ids:
@@ -628,11 +637,14 @@ def cmd_ideation_submit(env: dict[str, str], args: argparse.Namespace) -> None:
         bearer=bearer,
     )
     _drop_claim(args.task_id)
-    print(json.dumps({
+    output: dict[str, object] = {
         "task_id": args.task_id,
         "status": "success",
         "idea_ids": idea_ids,
-    }, indent=2))
+    }
+    if warnings:
+        output["warnings"] = warnings
+    print(json.dumps(output, indent=2))
 
 
 # ----------------------------------------------------------- execution-submit

--- a/reference/services/web-ui/src/eden_web_ui/routes/ideator.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/ideator.py
@@ -339,18 +339,24 @@ def _persist_idea_drafts(
     request: Request,
     drafts: list[Any],
     draft_rows: list[int],
-) -> tuple[list[str], HTMLResponse | None, FormErrors | None]:
+) -> tuple[list[str], list[str], HTMLResponse | None, FormErrors | None]:
     """Phase 1+2: write artifacts, create ideas as drafting, flip to ready.
 
-    Returns ``(idea_ids, error_response, validation_errors)``:
+    Returns ``(idea_ids, slug_warnings, error_response, validation_errors)``:
 
-    - ``(ids, None, None)`` on success;
-    - ``([], error_response, None)`` on a ``DispatchError`` from either
-      phase (rendered as the wire-error page);
-    - ``([], None, errors)`` on a Pydantic ``ValidationError`` raised by
-      ``Idea(**kwargs)``. The caller re-renders the draft form with the
-      per-row field errors — no store mutation has happened yet because
-      the Idea construction precedes the create_idea call.
+    - ``(ids, warnings, None, None)`` on success;
+    - ``([], [], error_response, None)`` on a ``DispatchError`` from
+      either phase (rendered as the wire-error page);
+    - ``([], [], None, errors)`` on a Pydantic ``ValidationError`` raised
+      by ``Idea(**kwargs)``. The caller re-renders the draft form with
+      the per-row field errors — no store mutation has happened yet
+      because the Idea construction precedes the create_idea call.
+
+    ``slug_warnings`` carries issue-#121 soft-check messages: after each
+    Idea is created, the experiment's existing ideas are scanned for
+    slug collisions; matches are reported as advisory strings. Slug
+    uniqueness is not a protocol invariant (idea identity is by
+    ``idea_id``), so warnings never block submission.
 
     The Phase-1 / Phase-2 split is preserved internally so a failure
     in mark-ready doesn't leave already-created drafting ideas
@@ -360,6 +366,7 @@ def _persist_idea_drafts(
     to its original row in the multi-row form.
     """
     idea_ids: list[str] = []
+    slug_warnings: list[str] = []
     artifacts_dir = request.app.state.artifacts_dir
     now: Callable[[], Any] = request.app.state.now
 
@@ -382,27 +389,35 @@ def _persist_idea_drafts(
             )
         except ValidationError as exc:
             errors = format_validation_errors(exc, row=row_index)
-            return [], None, errors
+            return [], [], None, errors
         write_idea_artifact(artifacts_dir, idea_id, draft.content)
         try:
             store.create_idea(idea)
         except DispatchError as exc:
-            return [], _render_error(
+            return [], [], _render_error(
                 request,
                 f"create_idea failed for {idea_id}: {wire_error_banner(exc)}",
             ), None
         idea_ids.append(idea_id)
+        # Issue #121 soft-check: warn the operator when a sibling idea
+        # in this experiment already uses the same slug.
+        for existing in store.list_ideas():
+            if existing.slug == idea.slug and existing.idea_id != idea_id:
+                slug_warnings.append(
+                    f"idea {idea_id}: slug {idea.slug!r} is already used "
+                    f"by idea {existing.idea_id!r}"
+                )
 
     for idea_id in idea_ids:
         try:
             store.mark_idea_ready(idea_id)
         except DispatchError as exc:
-            return [], _render_error(
+            return [], [], _render_error(
                 request,
                 f"mark_idea_ready failed for {idea_id}: {wire_error_banner(exc)}",
             ), None
 
-    return idea_ids, None, None
+    return idea_ids, slug_warnings, None, None
 
 
 @router.post("/{task_id}/submit", response_model=None)
@@ -461,7 +476,7 @@ async def submit_idea(task_id: str, request: Request) -> HTMLResponse | Redirect
             task_id=task_id, errors=errors, form_state=form_state, slugs=slugs,
         )
 
-    idea_ids, persist_error, validation_errors = _persist_idea_drafts(
+    idea_ids, slug_warnings, persist_error, validation_errors = _persist_idea_drafts(
         store=store, request=request, drafts=drafts, draft_rows=draft_rows,
     )
     if validation_errors is not None:
@@ -490,7 +505,8 @@ async def submit_idea(task_id: str, request: Request) -> HTMLResponse | Redirect
     _CLAIMS.pop(_claim_key(session.csrf, task_id), None)
     _DRAFT_BUFFERS.pop(_claim_key(session.csrf, task_id), None)
     return _render_submitted(
-        request, task_id, status="success", idea_ids=tuple(idea_ids)
+        request, task_id, status="success", idea_ids=tuple(idea_ids),
+        slug_warnings=tuple(slug_warnings),
     )
 
 
@@ -729,6 +745,7 @@ def _render_submitted(
     *,
     status: str,
     idea_ids: tuple[str, ...],
+    slug_warnings: tuple[str, ...] = (),
 ) -> HTMLResponse:
     return request.app.state.templates.TemplateResponse(
         request,
@@ -737,6 +754,7 @@ def _render_submitted(
             "task_id": task_id,
             "status": status,
             "idea_ids": idea_ids,
+            "slug_warnings": slug_warnings,
         },
     )
 

--- a/reference/services/web-ui/src/eden_web_ui/templates/ideator_submitted.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/ideator_submitted.html
@@ -9,5 +9,13 @@
 {% for pid in idea_ids %}<li><code>{{ pid }}</code></li>{% endfor %}
 </ul>
 {% endif %}
+{% if slug_warnings %}
+<div class="slug-warnings" role="alert">
+  <p><strong>warnings:</strong></p>
+  <ul>
+  {% for w in slug_warnings %}<li>{{ w }}</li>{% endfor %}
+  </ul>
+</div>
+{% endif %}
 <p><a href="/ideator/">back to ideator</a></p>
 {% endblock %}

--- a/reference/services/web-ui/tests/test_ideator_flow.py
+++ b/reference/services/web-ui/tests/test_ideator_flow.py
@@ -78,6 +78,71 @@ class TestHappyPath:
         assert store.list_ideas() == []
 
 
+class TestSlugSoftCheck:
+    """Issue #121: when an ideator submits an idea whose slug collides
+    with an existing idea in the experiment, the submitted page surfaces
+    an advisory warning. Submission still succeeds — slug uniqueness is
+    not a protocol invariant.
+    """
+
+    def _seed_ready_idea(self, store: InMemoryStore, *, idea_id: str, slug: str) -> None:
+        from eden_contracts import Idea
+        store.create_idea(
+            Idea.model_validate(
+                {
+                    "idea_id": idea_id,
+                    "experiment_id": EXPERIMENT_ID,
+                    "slug": slug,
+                    "priority": 0.0,
+                    "parent_commits": ["a" * 40],
+                    "artifacts_uri": "file:///tmp/seed.md",
+                    "state": "drafting",
+                    "created_at": "2026-05-01T00:00:00Z",
+                }
+            )
+        )
+        store.mark_idea_ready(idea_id)
+
+    def test_duplicate_slug_surfaces_warning_on_success_page(
+        self, signed_in_client: TestClient, store: InMemoryStore
+    ) -> None:
+        self._seed_ready_idea(store, idea_id="idea-prior", slug="dup-slug")
+        store.create_ideation_task("t-dup")
+        token = get_csrf(signed_in_client)
+        signed_in_client.post(
+            "/ideator/t-dup/claim",
+            data={"csrf_token": token},
+            follow_redirects=False,
+        )
+        form = _draft_form("dup-slug") | {"csrf_token": token}
+        resp = signed_in_client.post("/ideator/t-dup/submit", data=form)
+        assert resp.status_code == 200
+        # Submission still succeeded.
+        assert store.read_task("t-dup").state == "submitted"
+        assert len(store.list_ideas(state="ready")) == 2
+        # Warning rendered on the success page.
+        body = resp.text
+        assert "warnings" in body.lower()
+        assert "dup-slug" in body
+        assert "idea-prior" in body
+
+    def test_unique_slug_does_not_render_warnings_block(
+        self, signed_in_client: TestClient, store: InMemoryStore
+    ) -> None:
+        store.create_ideation_task("t-uniq")
+        token = get_csrf(signed_in_client)
+        signed_in_client.post(
+            "/ideator/t-uniq/claim",
+            data={"csrf_token": token},
+            follow_redirects=False,
+        )
+        form = _draft_form("unique-slug") | {"csrf_token": token}
+        resp = signed_in_client.post("/ideator/t-uniq/submit", data=form)
+        assert resp.status_code == 200
+        # No warnings block on the unique-slug submission.
+        assert 'class="slug-warnings"' not in resp.text
+
+
 class TestValidationRecovery:
     def test_invalid_form_re_renders_with_errors_and_input_preserved(
         self, signed_in_client: TestClient, store: InMemoryStore

--- a/spec/v0/07-wire-protocol.md
+++ b/spec/v0/07-wire-protocol.md
@@ -180,6 +180,8 @@ On success the server returns 204 with an empty body. The single-event append is
 
 Request and response bodies match [`schemas/idea.schema.json`](schemas/idea.schema.json). `list_ideas` accepts an optional `state` query parameter. `mark-ready` has an empty request body.
 
+`create_idea` MAY include an additional advisory field `warnings: list[string]` in its response body alongside the idea fields. Warnings are non-normative diagnostic strings (e.g., a soft-check that the submitted `slug` collides with an existing idea in the same experiment — slug uniqueness is not a protocol invariant per [`02-data-model.md`](02-data-model.md) §5.1, so the request still succeeds 200). Implementations MAY omit the field; clients MUST NOT rely on its presence or contents for correctness.
+
 ## 4. Variant operations
 
 | Operation | HTTP | Path | Auth |


### PR DESCRIPTION
Closes #121. Delegate-authored WIP; orchestrator committed + pushed after delegate session went orphan. ~252 line additions across spec / wire server / web-ui / eden-manual / tests.