### PR TITLE
Fix smoke quiescence after #215 retired EDEN_IDEATION_POLICY env var

### DIFF
--- a/reference/compose/healthcheck/smoke-checkpoint.sh
+++ b/reference/compose/healthcheck/smoke-checkpoint.sh
@@ -87,9 +87,6 @@ bash "${REPO_ROOT}/reference/scripts/setup-experiment/setup-experiment.sh" \
     --env-file "$ENV_FILE" \
     --data-root "$SMOKE_DATA_ROOT"
 
-# Same quiescence pin as smoke.sh: cap ideation at 3 so the
-# orchestrator loop terminates after the 3 variants land.
-sed -i.bak 's/^EDEN_IDEATION_POLICY_MAX_TOTAL=.*/EDEN_IDEATION_POLICY_MAX_TOTAL=3/' "$ENV_FILE"
 rm -f "${ENV_FILE}.bak"
 
 EDEN_ADMIN_TOKEN="$(grep -E '^EDEN_ADMIN_TOKEN=' "$ENV_FILE" | cut -d= -f2-)"

--- a/tests/fixtures/experiment/.eden/config.yaml
+++ b/tests/fixtures/experiment/.eden/config.yaml
@@ -7,3 +7,13 @@ evaluation_schema:
 objective:
   expr: "score"
   direction: "maximize"
+# fixed_total(3) makes the smoke deterministic: the orchestrator creates
+# exactly 3 ideation tasks then quiesces, so the smoke's quiescence-wait
+# is finite. Without this, the default maintain_pending(target=3) keeps
+# the queue at depth 3 indefinitely and the smoke times out.
+# (#215 / #133 retired the EDEN_IDEATION_POLICY_MAX_TOTAL env var that
+# previously pinned this; smoke{,-checkpoint}.sh now rely on the
+# fixture-config value.)
+ideation_policy:
+  kind: fixed_total
+  total: 3


### PR DESCRIPTION
All 7 in-flight PRs fail compose-smoke-checkpoint with 'orchestrator did not exit within 600s'. Root cause: #215 (#133) moved ideation policy from env vars to YAML config, but smoke.sh + smoke-checkpoint.sh still tried to pin via EDEN_IDEATION_POLICY_MAX_TOTAL=3 — that path is dead, so default maintain_pending(target=3) ran forever and the smoke timed out.

Pin ideation_policy: {kind: fixed_total, total: 3} in fixture config; strip dead sed-rewrite from both smoke scripts.

Blocks: #199, #218, #219, #220, #221, #222, #223.