### PR TITLE
CI: per-PR job gating based on touched paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,35 @@ on:
 # which never creates the check and leaves it Pending forever, deadlocking
 # the merge). So gating here is safe for the 12 required contexts.
 #
-# Gating applies to `pull_request` ONLY. On push-to-main and merge_group
-# every job runs unconditionally (the `github.event_name != 'pull_request'`
-# clause), giving a full post-merge safety net that catches any gating
-# mistake while it's still revertable. PR checks are the only pre-merge
-# gate (no merge queue, 0 required reviews), so filters are deliberately
-# biased toward over-inclusion: a false positive wastes minutes, a false
-# negative skips validation.
+# Every downstream gate has the shape:
+#
+#   if: >-
+#     !cancelled() && (
+#     needs.changes.result != 'success' ||
+#     needs.changes.outputs.run_all == 'true' ||
+#     needs.changes.outputs.<bucket> == 'true' )
+#
+# The three OR clauses, in order, are the safety design:
+#
+#   1. `needs.changes.result != 'success'` — FAIL-SAFE. If the detector
+#      job errors, every gated job runs the FULL suite rather than
+#      green-skipping. A false negative (skipping validation a change
+#      needed) is the dangerous mode here, because PR checks are the only
+#      pre-merge gate (no merge queue, 0 required reviews). Issue #225
+#      additionally makes `changes` a required check; this clause is the
+#      in-workflow belt to that branch-protection suspenders.
+#   2. `run_all` — true when the event is NOT a pull_request (push-to-main
+#      / merge_group get the full suite as a post-merge safety net) OR the
+#      workflow file itself changed (a PR editing a job definition must run
+#      that job to validate the edit). Computed in the `gate` step below so
+#      it survives a skipped/failed filter step.
+#   3. the per-job bucket(s) — the actual path-based gating.
+#
+# `!cancelled()` is required because using `needs.changes.result` forces
+# the gate to opt out of the default "skip on failed dependency" behavior;
+# without it a manual cancel wouldn't propagate. Filters are biased toward
+# over-inclusion: a false positive wastes minutes, a false negative skips
+# validation.
 
 jobs:
   changes:
@@ -42,12 +64,12 @@ jobs:
       contracts: ${{ steps.filter.outputs.contracts }}
       compose: ${{ steps.filter.outputs.compose }}
       conformance: ${{ steps.filter.outputs.conformance }}
-      workflow: ${{ steps.filter.outputs.workflow }}
+      run_all: ${{ steps.gate.outputs.run_all }}
     steps:
       # No checkout needed: on pull_request, dorny/paths-filter lists changed
       # files via the GitHub API (needs pull-requests: read). The step is
-      # skipped on push / merge_group, where every downstream gate runs full
-      # regardless of these outputs.
+      # skipped on push / merge_group, where `run_all` is true regardless of
+      # these outputs.
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request'
@@ -84,13 +106,32 @@ jobs:
             workflow:
               - '.github/workflows/ci.yml'
 
+      # `run_all` collapses two "run the whole suite" triggers into one
+      # output: (a) the event is not a pull_request — push-to-main and
+      # merge_group get the full post-merge safety net; (b) the workflow
+      # file itself changed — a PR editing a job definition must run that
+      # job to validate the edit, so a workflow-only PR runs everything.
+      # This step has no `if:`, so it runs on every event; on non-PR events
+      # the filter step is skipped and its `workflow` output is empty, which
+      # the event_name check below already covers.
+      - id: gate
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ] \
+             || [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+            echo "run_all=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_all=false" >> "$GITHUB_OUTPUT"
+          fi
+
   docs-lint:
     name: docs-lint
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.docs == 'true'
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
+      needs.changes.outputs.docs == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -111,11 +152,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.docs == 'true' ||
       needs.changes.outputs.spec == 'true' ||
       needs.changes.outputs.python == 'true' ||
-      needs.changes.outputs.compose == 'true'
+      needs.changes.outputs.compose == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -132,8 +175,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.python == 'true'
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -153,8 +198,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.schemas == 'true'
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
+      needs.changes.outputs.schemas == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -181,8 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.python == 'true'
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -203,8 +252,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.python == 'true'
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -225,9 +276,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.python == 'true' ||
-      needs.changes.outputs.spec == 'true'
+      needs.changes.outputs.spec == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -252,9 +305,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.spec == 'true' ||
-      needs.changes.outputs.contracts == 'true'
+      needs.changes.outputs.contracts == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -278,13 +333,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: changes
-    # `workflow` is included here so a workflow-only change still runs one
-    # representative compose smoke as an end-to-end self-test of the gating.
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true' ||
-      needs.changes.outputs.workflow == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -304,9 +358,11 @@ jobs:
     timeout-minutes: 15
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -331,9 +387,11 @@ jobs:
     timeout-minutes: 25
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -377,9 +435,11 @@ jobs:
     timeout-minutes: 15
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -399,9 +459,11 @@ jobs:
     timeout-minutes: 20
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -427,9 +489,11 @@ jobs:
     timeout-minutes: 20
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -449,9 +513,11 @@ jobs:
     timeout-minutes: 20
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.compose == 'true' ||
-      needs.changes.outputs.python == 'true'
+      needs.changes.outputs.python == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -482,9 +548,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
       needs.changes.outputs.python == 'true' ||
-      needs.changes.outputs.spec == 'true'
+      needs.changes.outputs.spec == 'true' )
     services:
       postgres:
         image: postgres:16.6-alpine
@@ -526,8 +594,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.conformance == 'true'
+      !cancelled() && (
+      needs.changes.result != 'success' ||
+      needs.changes.outputs.run_all == 'true' ||
+      needs.changes.outputs.conformance == 'true' )
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,90 @@ on:
     branches: [main]
   merge_group:
 
+# Per-PR job gating: a single `changes` detector job classifies the PR's
+# touched paths into coarse buckets, and every downstream job carries an
+# `if:` gate keyed off those buckets. This lets docs-only / spec-only /
+# conformance-only PRs skip the expensive compose smokes, e2e, postgres,
+# and conformance jobs they don't exercise.
+#
+# Why this works with branch protection: a job skipped via a job-level
+# `if:` reports a "skipped" conclusion, which branch protection's required
+# status checks treat as PASSING (unlike a workflow-level `paths:` filter,
+# which never creates the check and leaves it Pending forever, deadlocking
+# the merge). So gating here is safe for the 12 required contexts.
+#
+# Gating applies to `pull_request` ONLY. On push-to-main and merge_group
+# every job runs unconditionally (the `github.event_name != 'pull_request'`
+# clause), giving a full post-merge safety net that catches any gating
+# mistake while it's still revertable. PR checks are the only pre-merge
+# gate (no merge queue, 0 required reviews), so filters are deliberately
+# biased toward over-inclusion: a false positive wastes minutes, a false
+# negative skips validation.
+
 jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      spec: ${{ steps.filter.outputs.spec }}
+      schemas: ${{ steps.filter.outputs.schemas }}
+      python: ${{ steps.filter.outputs.python }}
+      contracts: ${{ steps.filter.outputs.contracts }}
+      compose: ${{ steps.filter.outputs.compose }}
+      conformance: ${{ steps.filter.outputs.conformance }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      # No checkout needed: on pull_request, dorny/paths-filter lists changed
+      # files via the GitHub API (needs pull-requests: read). The step is
+      # skipped on push / merge_group, where every downstream gate runs full
+      # regardless of these outputs.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            docs:
+              - '*.md'
+              - '**/*.md'
+              - 'docs/**'
+            spec:
+              - 'spec/**'
+            schemas:
+              - 'spec/v0/schemas/**'
+              - 'tests/fixtures/experiment/.eden/config.yaml'
+            python:
+              - 'reference/packages/**'
+              - 'reference/services/**'
+              - 'conformance/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'scripts/**'
+              - 'tests/**'
+            contracts:
+              - 'reference/packages/eden-contracts/**'
+              - 'spec/v0/schemas/**'
+            compose:
+              - 'reference/compose/**'
+              - 'reference/scripts/**'
+            conformance:
+              - 'conformance/**'
+              - 'reference/packages/**'
+              - 'reference/services/**'
+              - 'spec/**'
+            workflow:
+              - '.github/workflows/ci.yml'
+
   docs-lint:
     name: docs-lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.docs == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -29,6 +109,13 @@ jobs:
   rename-discipline:
     name: rename-discipline
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.docs == 'true' ||
+      needs.changes.outputs.spec == 'true' ||
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.compose == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -43,6 +130,10 @@ jobs:
   complexity-gate:
     name: complexity-gate
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -60,6 +151,10 @@ jobs:
   schema-validity:
     name: schema-validity
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.schemas == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -84,6 +179,10 @@ jobs:
   python-lint:
     name: python-lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -102,6 +201,10 @@ jobs:
   python-typecheck:
     name: python-typecheck
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -120,6 +223,11 @@ jobs:
   python-test:
     name: python-test
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.spec == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -142,6 +250,11 @@ jobs:
   schema-parity:
     name: schema-parity
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.spec == 'true' ||
+      needs.changes.outputs.contracts == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -164,6 +277,14 @@ jobs:
     name: compose-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    # `workflow` is included here so a workflow-only change still runs one
+    # representative compose smoke as an end-to-end self-test of the gating.
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.workflow == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -181,6 +302,11 @@ jobs:
     name: compose-smoke-subprocess
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -203,6 +329,11 @@ jobs:
     name: compose-smoke-subprocess-docker
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -244,6 +375,11 @@ jobs:
     name: compose-smoke-manual-mode
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -261,6 +397,11 @@ jobs:
     name: compose-smoke-multi-orchestrator
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -284,6 +425,11 @@ jobs:
     name: compose-smoke-checkpoint
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -301,6 +447,11 @@ jobs:
     name: compose-e2e
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.python == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -329,6 +480,11 @@ jobs:
   python-test-postgres:
     name: python-test-postgres
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.spec == 'true'
     services:
       postgres:
         image: postgres:16.6-alpine
@@ -368,6 +524,10 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.conformance == 'true'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
               - '*.md'
               - '**/*.md'
               - 'docs/**'
+              # docs-lint auto-discovers this config (no --config override);
+              # the ISSUE_TEMPLATE dir holds the .yml that rename-discipline
+              # scans (its .md siblings already match '**/*.md').
+              - '.markdownlint.json'
+              - '.github/ISSUE_TEMPLATE/**'
             spec:
               - 'spec/**'
             schemas:
@@ -98,6 +103,10 @@ jobs:
             compose:
               - 'reference/compose/**'
               - 'reference/scripts/**'
+              # The compose image build context is the repo root (`../..`),
+              # so the root .dockerignore directly shapes every compose
+              # smoke / e2e image build.
+              - '.dockerignore'
             conformance:
               - 'conformance/**'
               - 'reference/packages/**'
@@ -114,6 +123,7 @@ jobs:
               - '.github/workflows/ci.yml'
               - 'pyproject.toml'
               - 'uv.lock'
+              - '.python-version'
 
       # `run_all` collapses the "run the whole suite" triggers into one
       # output: (a) the event is not a pull_request — push-to-main and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,11 +194,15 @@ jobs:
     name: complexity-gate
     runs-on: ubuntu-latest
     needs: changes
+    # `compose` is included because radon scans all of reference/ — which
+    # includes reference/compose/healthcheck/e2e_drive.py, a .py file that
+    # lives in the compose bucket, not the python bucket.
     if: >-
       !cancelled() && (
       needs.changes.result != 'success' ||
       needs.changes.outputs.run_all == 'true' ||
-      needs.changes.outputs.python == 'true' )
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.compose == 'true' )
     steps:
       - uses: actions/checkout@v4
 
@@ -247,11 +251,17 @@ jobs:
     name: python-lint
     runs-on: ubuntu-latest
     needs: changes
+    # `compose` is included because `ruff check .` lints the whole repo —
+    # including reference/compose/healthcheck/e2e_drive.py, a .py file that
+    # lives in the compose bucket, not the python bucket. (pyright's
+    # explicit include list excludes reference/compose, so python-typecheck
+    # does not need this.)
     if: >-
       !cancelled() && (
       needs.changes.result != 'success' ||
       needs.changes.outputs.run_all == 'true' ||
-      needs.changes.outputs.python == 'true' )
+      needs.changes.outputs.python == 'true' ||
+      needs.changes.outputs.compose == 'true' )
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,12 @@ on:
 #      additionally makes `changes` a required check; this clause is the
 #      in-workflow belt to that branch-protection suspenders.
 #   2. `run_all` — true when the event is NOT a pull_request (push-to-main
-#      / merge_group get the full suite as a post-merge safety net) OR the
-#      workflow file itself changed (a PR editing a job definition must run
-#      that job to validate the edit). Computed in the `gate` step below so
-#      it survives a skipped/failed filter step.
+#      / merge_group get the full suite as a post-merge safety net) OR a
+#      rootcfg file changed (the workflow file — a PR editing a job
+#      definition must run that job to validate the edit — or the root
+#      pyproject.toml / uv.lock, which every uv-sync job depends on).
+#      Computed in the `gate` step below so it survives a skipped/failed
+#      filter step.
 #   3. the per-job bucket(s) — the actual path-based gating.
 #
 # `!cancelled()` is required because using `needs.changes.result` forces
@@ -88,8 +90,6 @@ jobs:
               - 'reference/packages/**'
               - 'reference/services/**'
               - 'conformance/**'
-              - 'pyproject.toml'
-              - 'uv.lock'
               - 'scripts/**'
               - 'tests/**'
             contracts:
@@ -103,21 +103,31 @@ jobs:
               - 'reference/packages/**'
               - 'reference/services/**'
               - 'spec/**'
-            workflow:
+            # rootcfg = workspace-global build config. The workflow file
+            # (any job definition) and the root pyproject.toml / uv.lock
+            # (consumed by every `uv sync --frozen` job: python-lint,
+            # python-typecheck, python-test, schema-parity, conformance,
+            # python-test-postgres, the compose image build). A change here
+            # forces the full suite via run_all, because no single bucket
+            # captures all the jobs these files affect.
+            rootcfg:
               - '.github/workflows/ci.yml'
+              - 'pyproject.toml'
+              - 'uv.lock'
 
-      # `run_all` collapses two "run the whole suite" triggers into one
+      # `run_all` collapses the "run the whole suite" triggers into one
       # output: (a) the event is not a pull_request — push-to-main and
-      # merge_group get the full post-merge safety net; (b) the workflow
-      # file itself changed — a PR editing a job definition must run that
-      # job to validate the edit, so a workflow-only PR runs everything.
+      # merge_group get the full post-merge safety net; (b) a rootcfg file
+      # changed — the workflow file (a PR editing a job definition must run
+      # that job to validate the edit) or the root pyproject.toml / uv.lock
+      # (affects every uv-sync job, which no single bucket captures).
       # This step has no `if:`, so it runs on every event; on non-PR events
-      # the filter step is skipped and its `workflow` output is empty, which
+      # the filter step is skipped and its `rootcfg` output is empty, which
       # the event_name check below already covers.
       - id: gate
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ] \
-             || [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+             || [ "${{ steps.filter.outputs.rootcfg }}" = "true" ]; then
             echo "run_all=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_all=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Adds a `changes` detector job (`dorny/paths-filter@v3`) that classifies each PR's touched paths into coarse buckets (`docs` / `spec` / `schemas` / `python` / `contracts` / `compose` / `conformance`), and gates every downstream job on those buckets via job-level `if:`. **Why:** plan-heavy and docs-only PRs were triggering the full ~30-min suite (compose-e2e + postgres + conformance + 6 compose smokes) despite touching zero code. A plan PR (`docs/plans/*.md`) now runs only `changes` + `docs-lint` + `rename-discipline`.
- **Gating applies to `pull_request` only.** Non-PR events (`push`-to-main, `merge_group`) and **any PR that edits `.github/workflows/ci.yml`** run the FULL suite — consolidated into a single `run_all` output. The push/merge case is a post-merge safety net (PR checks are the only pre-merge gate here — no merge queue, 0 required reviews). The workflow-file case ensures a PR editing a job definition actually runs that job to validate the edit.
- Filters are biased toward **over-inclusion** (a false positive wastes minutes; a false negative skips validation): `python` includes `pyproject.toml`/`uv.lock`/`scripts/`/`tests/`; `conformance` includes all reference packages + spec; `python-test`/`schema-parity`/`python-test-postgres` also fire on `spec` changes (schema files feed the contracts/storage tests).

### Two safety properties baked into every gate

Every downstream gate has the shape:

```yaml
if: >-
  !cancelled() && (
  needs.changes.result != 'success' ||   # 1. fail-safe
  needs.changes.outputs.run_all == 'true' ||  # 2. non-PR or workflow edit
  needs.changes.outputs.<bucket> == 'true' )  # 3. path gating
```

1. **Skipped ≠ deadlock.** A job skipped via job-level `if:` reports a "skipped" conclusion, which branch protection treats as **passing** — unlike a workflow-level `paths:` filter, which never creates the check and leaves the required context Pending forever. So gating is safe for all 12 required contexts.
2. **Detector-failure fail-safe.** If the `changes` job itself errors, `needs.changes.result != 'success'` fans every gated job out to the full suite instead of green-skipping. `!cancelled()` is required because referencing `needs.changes.result` opts the gate out of the default skip-on-failed-dependency behavior. This is the in-workflow belt; #225 adds `changes` as a required check (the branch-protection suspenders).

### Gating map (what runs on a `pull_request`)

| Job | Runs when bucket(s) touched |
|---|---|
| `docs-lint` | `docs` |
| `rename-discipline` | `docs` \| `spec` \| `python` \| `compose` |
| `complexity-gate` / `python-lint` / `python-typecheck` | `python` |
| `schema-validity` | `schemas` |
| `python-test` / `python-test-postgres` | `python` \| `spec` |
| `schema-parity` | `spec` \| `contracts` |
| 6 compose smokes + `compose-e2e` | `compose` \| `python` |
| `conformance` | `conformance` (= `conformance/` \| reference packages/services \| `spec`) |

…plus the universal `run_all` (non-PR event OR workflow-file edit) and the detector fail-safe on every job.

## What this does NOT cover

- **Branch-protection coupling** — the in-workflow fail-safe handles a *failed* detector, but making `changes` a required status check is the complementary guarantee. Operator-managed; tracked in **#225**.
- **Per-package test granularity** — the original spec floated splitting `python-test` per package (skip web-ui tests when only `eden-storage` changes). Deliberately not done: it adds required-check contexts + branch-protection churn for modest gain, since the dominant cost is the compose/e2e/postgres/conformance jobs already gated off. Tracked in **#226**.
- **`merge_group` reliability** — the `merge_group:` trigger is currently vestigial (no merge queue configured); it runs the full suite via `run_all` and is otherwise unexercised here.

## Fresh-operator walkthrough

N/A — internal CI change only (no operator-facing template / route / CLI / wire surface).

## Test plan

- [x] `actionlint .github/workflows/ci.yml` — clean (exit 0), both rounds
- [x] YAML parses; 18 jobs, all 17 downstream gates uniform with the fail-safe + `run_all` + bucket shape
- [x] Simulated gating: plan/docs-only PR → only `changes` + `docs-lint` + `rename-discipline`; python-only PR → skips conformance only if conformance/spec untouched; etc.
- [x] Codex-review (4 substantive rounds + final confirmation): R1 detector-failure green-skip cascade + workflow-only PRs bypassing edited jobs; R2 `pyproject.toml`/`uv.lock` skipping uv-sync jobs; R3 `.dockerignore`/`.markdownlint.json`/issue-template config unbucketed; R4 `e2e_drive.py` skipping `python-lint`/`complexity-gate`. R5 confirmed clean — ready to merge.
- [x] **Self-test on this PR** — because this PR edits `ci.yml`, `run_all` is true, so it runs the FULL suite end-to-end. This is intentional: the one PR that changes the gating validates the entire new workflow. The CI *savings* are demonstrated by the next docs/plan PR, not this one. **Observed:** `changes` job fired, all 17 downstream jobs triggered (none wrongly skipped) — gating mechanics validated.

## Related issues

- Refs #225 — add `changes` to required status checks (branch-protection complement to the in-workflow fail-safe)
- Refs #226 — per-package python-test granularity (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
