### PR TITLE
Fix #212: executor-side multi-file artifact upload UX (follow-up to #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Per-chunk entries preserve the full implementation record: contract amendments, 
 
 ## [Unreleased]
 
+### Executor-side multi-file artifact upload UX (issue #212; follow-up to #120)
+
+Extends the issue-#120 multi-file artifact upload UX (text box + file uploads → server-side `.tar.gz` bundle with a top-level `manifest.json`) to the executor submission form. #120 landed this on the ideator + evaluator forms and deferred the executor surface; this closes that gap so executors can attach build outputs, screenshots, profiling captures, etc. alongside their variant submission.
+
+**Template.** [`executor_claim.html`](reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html) gains `enctype="multipart/form-data"` and an `artifact (optional)` fieldset mirroring the evaluator form: an `artifact_text` markdown textarea, a `multiple` `artifact_files` input, and the existing `artifacts_uri` field repositioned as an explicit-URI override ("when set, text / uploads above are ignored"). The fieldset surfaces both the `artifact` (bundling collision / filename rejection) and `artifacts_uri` per-field errors. [`executor_submitted.html`](reference/services/web-ui/src/eden_web_ui/templates/executor_submitted.html) now renders the resulting `artifacts_uri` as a scheme-aware link, matching `evaluator_submitted.html`.
+
+**Route.** [`routes/executor.py`](reference/services/web-ui/src/eden_web_ui/routes/executor.py) reuses the `predict_artifact_uri`-adjacent `write_artifact_bundle` helper from [`artifacts.py`](reference/services/web-ui/src/eden_web_ui/artifacts.py). New `_collect_uploads` + `_maybe_bundle_executor_artifact` helpers mirror the evaluator route exactly; `_parse_submit_form` now collects uploads and rewrites the draft's `artifacts_uri` to the freshly-bundled artifact (single-file `.md`/`<ext>` or `.tar.gz`) when the operator supplies text/uploads instead of an explicit URI. The bundle text entry lands at the role-coherent `variant.md` headline (cf. `idea.md` / `evaluation.md`). The `artifacts_uri` already flowed through `VariantSubmission` onto `Variant.executor_artifacts_uri` (spec `03-roles.md` §3.4, issues #164/#165) — only the URI-production path is new. The executor's separate `Variant.description` field is unchanged.
+
+**Tests.** New [`test_executor_multifile.py`](reference/services/web-ui/tests/test_executor_multifile.py) mirrors `test_evaluator_multifile.py` / `test_ideator_multifile.py`: text+files → `.tar.gz` (with per-entry serving round-trip), text-only → `.md`, single-file → raw `<ext>`, explicit URI overrides bundling, and the no-artifact path stays `artifacts_uri == None`. All cases drive the executor's `status="success"` git-reachability gates with a real child commit.
+
 ### Refactor F-1: split `eden-storage._StoreBase` into a mixin family (issue #114)
 
 Code-quality follow-up from the Phase-A audit ([`docs/audits/2026-05-20-phase-c-disposition.md`](docs/audits/2026-05-20-phase-c-disposition.md) §1 F-1). The 1,638-SLOC `_base.py` monolith (MI 0.00, carried under a `# slop-allow-file:` annotation deferring the split to #114) is split into a thin core plus a per-resource mixin family. **Behavior-preserving by construction** — no spec, schema, wire, or `Store`-Protocol change; the only observable difference is internal file layout.

--- a/reference/services/web-ui/src/eden_web_ui/routes/executor.py
+++ b/reference/services/web-ui/src/eden_web_ui/routes/executor.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import contextlib
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import timedelta
 from typing import Any
 
@@ -36,8 +37,10 @@ from eden_storage import (
 )
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from starlette.datastructures import UploadFile
 
-from ..forms import parse_implement_form
+from ..artifacts import UploadedFile, write_artifact_bundle
+from ..forms import FormErrors, parse_implement_form
 from ._helpers import (
     csrf_ok,
     get_session,
@@ -270,6 +273,7 @@ def _phase3_submit_with_readback(
             commit_sha=draft.commit_sha,
             branch=branch if draft.status == "success" else None,
             status=draft.status,
+            artifacts_uri=draft.artifacts_uri,
         )
     return _render_orphaned(
         request,
@@ -539,7 +543,11 @@ async def submit(  # noqa: PLR0911 — flow has many distinct outcome arms by de
     except DispatchError as exc:
         return _render_error(request, wire_error_banner(exc))
 
-    draft, errors, form_state = _parse_submit_form(form)
+    draft, errors, form_state = _parse_submit_form(
+        form,
+        request=request,
+        uploaded=await _collect_uploads(form, field_name="artifact_files"),
+    )
     if draft is None:
         return _render_draft(
             request,
@@ -672,12 +680,24 @@ def _phase2_publish_work_ref_or_orphan(
     )
 
 
-def _parse_submit_form(form: Any) -> tuple[Any, Any, dict[str, str]]:
-    """Parse the implement-form fields. Returns ``(draft, errors, form_state)``."""
+def _parse_submit_form(
+    form: Any,
+    *,
+    request: Request,
+    uploaded: list[UploadedFile],
+) -> tuple[Any, Any, dict[str, str]]:
+    """Parse the implement-form fields. Returns ``(draft, errors, form_state)``.
+
+    Mirrors the evaluator's ``_parse_evaluator_submit_form`` (issue #120):
+    when the operator supplies text and/or file uploads instead of an
+    explicit ``artifacts_uri``, the draft's ``artifacts_uri`` is rewritten
+    to point at a freshly-bundled artifact (single-file or ``.tar.gz``).
+    """
     status_raw = str(form.get("status") or "")
     commit_sha_raw = str(form.get("commit_sha") or "")
     description_raw = str(form.get("description") or "")
     artifacts_uri_raw = str(form.get("artifacts_uri") or "")
+    artifact_text_raw = str(form.get("artifact_text") or "")
     draft, errors = parse_implement_form(
         status_raw=status_raw,
         commit_sha_raw=commit_sha_raw,
@@ -689,8 +709,91 @@ def _parse_submit_form(form: Any) -> tuple[Any, Any, dict[str, str]]:
         "commit_sha": commit_sha_raw,
         "description": description_raw,
         "artifacts_uri": artifacts_uri_raw,
+        "artifact_text": artifact_text_raw,
     }
+    if draft is None:
+        return None, errors, form_state
+
+    written_uri, bundle_error = _maybe_bundle_executor_artifact(
+        request=request,
+        artifacts_uri_raw=artifacts_uri_raw,
+        artifact_text_raw=artifact_text_raw,
+        uploaded=uploaded,
+    )
+    if bundle_error is not None:
+        new_errors = errors or FormErrors()
+        new_errors.add(0, "artifact", bundle_error)
+        return None, new_errors, form_state
+    if written_uri is not None:
+        draft = replace(draft, artifacts_uri=written_uri)
+        form_state["artifacts_uri"] = written_uri
     return draft, errors, form_state
+
+
+def _maybe_bundle_executor_artifact(
+    *,
+    request: Request,
+    artifacts_uri_raw: str,
+    artifact_text_raw: str,
+    uploaded: list[UploadedFile],
+) -> tuple[str | None, str | None]:
+    """Decide whether to write a new bundled executor artifact.
+
+    Mirrors the evaluator's ``_maybe_bundle_evaluator_artifact``.
+    Returns ``(uri, error)``:
+
+    - ``(None, None)`` if the operator supplied an explicit
+      ``artifacts_uri`` OR provided neither text nor uploads — no new
+      artifact is written.
+    - ``(uri, None)`` on a successful write — the caller pins
+      ``draft.artifacts_uri`` to ``uri``.
+    - ``(None, msg)`` on a bundling collision / filename rejection — the
+      caller turns ``msg`` into a per-field form error.
+    """
+    if artifacts_uri_raw.strip():
+        return None, None
+    if not (artifact_text_raw.strip() or uploaded):
+        return None, None
+    try:
+        uri = write_artifact_bundle(
+            request.app.state.artifacts_dir,
+            f"variant-artifact-{uuid.uuid4().hex}",
+            text_content=artifact_text_raw,
+            text_filename="variant.md",
+            uploads=uploaded,
+        )
+    except ValueError as exc:
+        return None, str(exc)
+    return uri, None
+
+
+async def _collect_uploads(
+    form: Any, *, field_name: str
+) -> list[UploadedFile]:
+    """Pull all ``UploadFile`` entries for ``field_name`` from ``form``.
+
+    Browser file inputs with ``multiple`` post one part per selected
+    file, all under the same field name; ``form.getlist(field_name)``
+    returns them in order. Drops empty-filename entries (Starlette's
+    representation of "user selected nothing") so the bundler doesn't
+    treat the absence-of-uploads as a single empty upload. Mirrors the
+    evaluator route's ``_collect_uploads``.
+    """
+    out: list[UploadedFile] = []
+    for item in form.getlist(field_name):
+        if not isinstance(item, UploadFile):
+            continue
+        if not item.filename:
+            continue
+        data = await item.read()
+        out.append(
+            UploadedFile(
+                filename=item.filename,
+                data=data,
+                content_type=item.content_type,
+            )
+        )
+    return out
 
 
 def _run_success_draft_gates(
@@ -784,6 +887,7 @@ def _render_submitted(
     commit_sha: str | None,
     branch: str | None,
     status: str,
+    artifacts_uri: str | None = None,
 ) -> HTMLResponse:
     return request.app.state.templates.TemplateResponse(
         request,
@@ -794,6 +898,7 @@ def _render_submitted(
             "commit_sha": commit_sha,
             "branch": branch,
             "status": status,
+            "artifacts_uri": artifacts_uri,
         },
     )
 
@@ -850,6 +955,7 @@ def _empty_form_state() -> dict[str, str]:
         "commit_sha": "",
         "description": "",
         "artifacts_uri": "",
+        "artifact_text": "",
     }
 
 

--- a/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html
@@ -84,7 +84,7 @@ git push origin my-work</code></pre></li>
         <div class="banner banner-error">{{ msg }}</div>
     {% endfor %}
     {% endif %}
-    <form action="/executor/{{ task_id }}/submit" method="post">
+    <form action="/executor/{{ task_id }}/submit" method="post" enctype="multipart/form-data">
         <input type="hidden" name="csrf_token" value="{{ session.csrf }}">
         <fieldset>
             <legend>status</legend>
@@ -111,14 +111,39 @@ git push origin my-work</code></pre></li>
             <label for="description">description (optional)</label><br>
             <textarea id="description" name="description" rows="3" cols="60">{{ form_state.description }}</textarea>
         </p>
-        <p>
-            <label for="artifacts_uri">artifacts_uri (optional; URI for build logs / screenshots / etc.)</label><br>
-            <input type="text" id="artifacts_uri" name="artifacts_uri" size="60"
-                value="{{ form_state.artifacts_uri or '' }}">
+        <fieldset class="artifact-bundle-uploads">
+            <legend>artifact (optional; build logs / screenshots / etc.)</legend>
+            <p>
+                <label for="artifact_text">notes / build log (markdown)</label><br>
+                <textarea id="artifact_text" name="artifact_text" rows="6" cols="60">{{ form_state.artifact_text or "" }}</textarea>
+            </p>
+            <p>
+                <label for="artifact_files">attach files</label><br>
+                <input type="file" id="artifact_files" name="artifact_files" multiple>
+                <small>
+                    text + uploads → wrapped server-side into a
+                    <code>.tar.gz</code> with a top-level
+                    <code>manifest.json</code>. Single file (text-only OR
+                    one upload) is stored directly.
+                </small>
+            </p>
+            <p>
+                <label for="artifacts_uri">or paste an existing <code>artifacts_uri</code> (URI to your build logs / output)</label><br>
+                <input type="text" id="artifacts_uri" name="artifacts_uri" size="60"
+                    value="{{ form_state.artifacts_uri or '' }}">
+                <small>
+                    when set, text / uploads above are ignored. Use this
+                    when you've already written your artifact somewhere
+                    the web-ui can reach.
+                </small>
+            </p>
+            {% if errors and errors.by_row.get(0, {}).get("artifact") %}
+            <span class="field-error">{{ errors.by_row[0]["artifact"] }}</span>
+            {% endif %}
             {% if errors and errors.by_row.get(0, {}).get("artifacts_uri") %}
             <span class="field-error">{{ errors.by_row[0]["artifacts_uri"] }}</span>
             {% endif %}
-        </p>
+        </fieldset>
         <p>worker branch (server-derived): <code>{{ branch }}</code></p>
         <button type="submit">submit</button>
     </form>

--- a/reference/services/web-ui/src/eden_web_ui/templates/executor_submitted.html
+++ b/reference/services/web-ui/src/eden_web_ui/templates/executor_submitted.html
@@ -11,6 +11,18 @@
     {% if branch %}
     <dt>worker branch</dt><dd><code>refs/heads/{{ branch }}</code></dd>
     {% endif %}
+    {% if artifacts_uri %}
+    <dt>artifacts_uri</dt><dd>
+        {% set scheme = artifacts_uri.split(":", 1)[0] | lower %}
+        {% if scheme == "file" %}
+        <a href="/artifacts?uri={{ artifacts_uri | urlencode }}" target="_blank" rel="noopener"><code>{{ artifacts_uri }}</code></a>
+        {% elif scheme in ("http", "https") %}
+        <a href="{{ artifacts_uri }}" target="_blank" rel="noopener"><code>{{ artifacts_uri }}</code></a>
+        {% else %}
+        <code>{{ artifacts_uri }}</code>
+        {% endif %}
+    </dd>
+    {% endif %}
 </dl>
 <p><a href="/executor/">back to executor list</a></p>
 {% endblock %}

--- a/reference/services/web-ui/tests/test_executor_multifile.py
+++ b/reference/services/web-ui/tests/test_executor_multifile.py
@@ -1,0 +1,207 @@
+"""Multi-file executor submission flow (issue #212; follow-up to #120)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import quote, urlparse
+
+import pytest
+from conftest import (
+    get_csrf,
+    make_child_commit,
+    seed_implement_task,
+)
+from eden_git import GitRepo
+from eden_storage import InMemoryStore, VariantSubmission
+from eden_web_ui.routes import executor as executor_routes
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_claims():
+    executor_routes._CLAIMS.clear()
+    yield
+    executor_routes._CLAIMS.clear()
+
+
+def _claim(
+    client: TestClient,
+    store: InMemoryStore,
+    base_sha: str,
+    *,
+    slug: str,
+) -> str:
+    task_id, _ = seed_implement_task(store, base_sha=base_sha, slug=slug)
+    csrf = get_csrf(client)
+    resp = client.post(
+        f"/executor/{task_id}/claim",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    return task_id
+
+
+def _variant_submission(store: InMemoryStore, task_id: str) -> VariantSubmission:
+    sub = store.read_submission(task_id)
+    assert isinstance(sub, VariantSubmission)
+    return sub
+
+
+class TestArtifactBundle:
+    def test_text_plus_files_writes_bundle(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+    ) -> None:
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="alpha")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "alpha-tip")
+
+        resp = signed_in_impl_client.post(
+            f"/executor/{task_id}/submit",
+            data={
+                "csrf_token": csrf,
+                "status": "success",
+                "commit_sha": child_sha,
+                "description": "alpha variant",
+                "artifact_text": "## build log\n\nbuilt cleanly",
+                "artifacts_uri": "",
+            },
+            files={"artifact_files": ("build.svg", b"<svg/>", "image/svg+xml")},
+        )
+        assert resp.status_code == 200, resp.text
+        recorded = _variant_submission(store, task_id)
+        assert recorded.artifacts_uri is not None
+        assert recorded.artifacts_uri.endswith(".tar.gz")
+
+        # The serving route streams entries by name out of the bundle.
+        uri = recorded.artifacts_uri
+        m = signed_in_impl_client.get(
+            f"/artifacts?uri={quote(uri, safe='')}&entry=variant.md"
+        )
+        assert m.status_code == 200
+        assert "build log" in m.text
+
+        s = signed_in_impl_client.get(
+            f"/artifacts?uri={quote(uri, safe='')}&entry=build.svg"
+        )
+        assert s.status_code == 200
+        assert s.content == b"<svg/>"
+
+    def test_only_text_writes_single_md(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+    ) -> None:
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="bravo")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "bravo-tip")
+
+        resp = signed_in_impl_client.post(
+            f"/executor/{task_id}/submit",
+            data={
+                "csrf_token": csrf,
+                "status": "success",
+                "commit_sha": child_sha,
+                "description": "",
+                "artifact_text": "## build log",
+                "artifacts_uri": "",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        recorded = _variant_submission(store, task_id)
+        assert recorded.artifacts_uri is not None
+        parsed = urlparse(recorded.artifacts_uri)
+        assert parsed.path.endswith(".md")
+        assert "build log" in Path(parsed.path).read_text()
+
+    def test_only_one_file_writes_single_artifact(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+    ) -> None:
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="charlie")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "charlie-tip")
+
+        resp = signed_in_impl_client.post(
+            f"/executor/{task_id}/submit",
+            data={
+                "csrf_token": csrf,
+                "status": "success",
+                "commit_sha": child_sha,
+                "description": "",
+                "artifact_text": "",
+                "artifacts_uri": "",
+            },
+            files={"artifact_files": ("out.bin", b"\x00\x01\x02", "application/octet-stream")},
+        )
+        assert resp.status_code == 200, resp.text
+        recorded = _variant_submission(store, task_id)
+        assert recorded.artifacts_uri is not None
+        parsed = urlparse(recorded.artifacts_uri)
+        assert parsed.path.endswith(".bin")
+        assert Path(parsed.path).read_bytes() == b"\x00\x01\x02"
+
+    def test_explicit_uri_overrides_bundling(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+    ) -> None:
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="delta")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "delta-tip")
+
+        explicit = "https://example.invalid/build-output.html"
+        resp = signed_in_impl_client.post(
+            f"/executor/{task_id}/submit",
+            data={
+                "csrf_token": csrf,
+                "status": "success",
+                "commit_sha": child_sha,
+                "description": "",
+                # Both an explicit URI AND text+files — explicit wins.
+                "artifact_text": "ignored",
+                "artifacts_uri": explicit,
+            },
+            files={"artifact_files": ("ignored.txt", b"x", "text/plain")},
+        )
+        assert resp.status_code == 200, resp.text
+        recorded = _variant_submission(store, task_id)
+        assert recorded.artifacts_uri == explicit
+
+    def test_no_text_no_files_no_uri_skips_artifact(
+        self,
+        signed_in_impl_client: TestClient,
+        store: InMemoryStore,
+        bare_repo: GitRepo,
+        base_sha: str,
+    ) -> None:
+        """Existing 'no artifact' path keeps working."""
+        task_id = _claim(signed_in_impl_client, store, base_sha, slug="echo")
+        csrf = get_csrf(signed_in_impl_client)
+        child_sha = make_child_commit(bare_repo, base_sha, "echo-tip")
+
+        resp = signed_in_impl_client.post(
+            f"/executor/{task_id}/submit",
+            data={
+                "csrf_token": csrf,
+                "status": "success",
+                "commit_sha": child_sha,
+                "description": "",
+                "artifact_text": "",
+                "artifacts_uri": "",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        recorded = _variant_submission(store, task_id)
+        assert recorded.artifacts_uri is None


### PR DESCRIPTION
## Summary

- Extends the issue-#120 multi-file artifact upload UX (text box + file uploads → server-side `.tar.gz` bundle with a top-level `manifest.json`) to the **executor** submission form. #120 landed this on the ideator + evaluator forms and deferred the executor surface; this closes that gap so executors can attach build outputs, screenshots, profiling captures, etc. alongside their variant submission.
- Mirrors the evaluator route/template pattern exactly — `_collect_uploads` + `_maybe_bundle_executor_artifact` + the `predict_artifact_uri`-adjacent `write_artifact_bundle` helper — so there is one shared bundling shape across all three roles.

## What this changes

**Template.** [`executor_claim.html`](reference/services/web-ui/src/eden_web_ui/templates/executor_claim.html) gains `enctype="multipart/form-data"` and an `artifact (optional)` fieldset: an `artifact_text` markdown textarea, a `multiple` `artifact_files` input, and the existing `artifacts_uri` field repositioned as an explicit-URI override ("when set, text / uploads above are ignored"). [`executor_submitted.html`](reference/services/web-ui/src/eden_web_ui/templates/executor_submitted.html) renders the resulting `artifacts_uri` as a scheme-aware link, matching `evaluator_submitted.html`.

**Route.** [`routes/executor.py`](reference/services/web-ui/src/eden_web_ui/routes/executor.py): `_parse_submit_form` now collects uploads and rewrites the draft's `artifacts_uri` to the freshly-bundled artifact (single-file `.md`/`<ext>` or `.tar.gz`) when the operator supplies text/uploads instead of an explicit URI. The bundle text entry lands at the role-coherent `variant.md` headline (cf. `idea.md` / `evaluation.md`). The `artifacts_uri` already flowed through `VariantSubmission` onto `Variant.executor_artifacts_uri` (spec `03-roles.md` §3.4, issues #164/#165) — **only the URI-production path is new**. The executor's separate `Variant.description` field is unchanged.

## What this does NOT cover

- No spec/wire changes — `VariantSubmission.artifacts_uri` and `Variant.executor_artifacts_uri` already existed (#164/#165); this PR only produces the URI from the form.
- The htmx add-row affordance is ideator-only (multi-row drafting); the executor submits a single variant, so no per-row upload plumbing is needed here.
- No deferred items.

## Fresh-operator walkthrough

- [x] Walkthrough performed against the changed surface via the new automated multifile tests, which drive the **real** claim → submit (multipart `artifact_files`) → bundle-write → per-entry serve round-trip through the live ASGI app (`TestClient`), rendering `executor_claim.html` and `executor_submitted.html` and reading entries back out of the served `.tar.gz`. The compose smoke additionally confirms the web-ui boots cleanly with these template/route edits.
- Notes: passed cleanly. text+files → `.tar.gz` (entries `variant.md` + uploaded file both served), text-only → `.md`, single-file → raw `<ext>`, explicit URI overrides bundling, and the no-artifact path stays `artifacts_uri == None`.

## Test plan

- [x] `uv run ruff check .` — passed
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -q reference/services/web-ui/tests/` — 629 passed
- [x] `uv run pytest -q` — 1947 passed, 221 skipped
- [x] `bash reference/compose/healthcheck/smoke.sh` — PASS

## Related issues

- Closes #212 — Executor-side multi-file artifact upload UX
- Refs #120 — the original multi-file UX (ideator + evaluator), PR #213
- Refs #164 / #165 — `executor_artifacts_uri` wire plumbing this builds on

🤖 Generated with [Claude Code](https://claude.com/claude-code)